### PR TITLE
fix: change from --job-spec to --spec [skip-validate-pr]

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -4,7 +4,7 @@
     "command": "agent:create",
     "flagAliases": [],
     "flagChars": ["f", "n", "o"],
-    "flags": ["api-version", "flags-dir", "job-spec", "json", "name", "target-org"],
+    "flags": ["api-version", "flags-dir", "json", "name", "spec", "target-org"],
     "plugin": "@salesforce/plugin-agent"
   },
   {

--- a/messages/agent.create.md
+++ b/messages/agent.create.md
@@ -4,13 +4,13 @@ Create an agent in your org from a local agent spec file.
 
 # description
 
-To generate an agent spec file, run the "agent generate spec" CLI command, which outputs a JSON file with the list of jobs and descriptions that the new agent can perform. Then specify this generated spec file to the --job-spec flag of this command, along with the name of the new agent.
+To generate an agent spec file, run the "agent generate spec" CLI command, which outputs a JSON file with the list of jobs and descriptions that the new agent can perform. Then specify this generated spec file to the --spec flag of this command, along with the name of the new agent.
 
 When this command finishes, your org contains the new agent, which you can then edit in the Agent Builder UI. The new agent already has a list of topics and actions that were automatically created from the list of jobs in the provided agent spec file. This command also retrieves all the metadata files associated with the new agent to your local DX project.
 
-To open the new agent in your org's Agent Builder UI, run this command: "sf org open agent --name <api-name-of-your-agent>". 
+To open the new agent in your org's Agent Builder UI, run this command: "sf org open agent --name <api-name-of-your-agent>".
 
-# flags.job-spec.summary
+# flags.spec.summary
 
 Path to an agent spec file.
 

--- a/messages/agent.create.md
+++ b/messages/agent.create.md
@@ -22,4 +22,4 @@ API name of the new agent.
 
 - Create an agent called "CustomerSupportAgent" in an org with alias "my-org" using the specified agent spec file:
 
-  <%= config.bin %> <%= command.id %> --name CustomerSupportAgent --job-spec ./config/agentSpec.json --target-org my-org
+  <%= config.bin %> <%= command.id %> --name CustomerSupportAgent --spec ./config/agentSpec.json --target-org my-org

--- a/src/commands/agent/create.ts
+++ b/src/commands/agent/create.ts
@@ -30,10 +30,10 @@ export default class AgentCreate extends SfCommand<AgentCreateResult> {
   public static readonly flags = {
     'target-org': Flags.requiredOrg(),
     'api-version': Flags.orgApiVersion(),
-    'job-spec': Flags.file({
+    spec: Flags.file({
       char: 'f',
       required: true,
-      summary: messages.getMessage('flags.job-spec.summary'),
+      summary: messages.getMessage('flags.spec.summary'),
     }),
     name: Flags.string({
       char: 'n',
@@ -44,7 +44,7 @@ export default class AgentCreate extends SfCommand<AgentCreateResult> {
 
   public async run(): Promise<AgentCreateResult> {
     const { flags } = await this.parse(AgentCreate);
-    const jsonParsingStage = `Parsing ${flags['job-spec']}`;
+    const jsonParsingStage = `Parsing ${flags.spec}`;
     const mso = new MultiStageOutput({
       jsonEnabled: this.jsonEnabled(),
       title: `Creating ${flags.name} Agent`,
@@ -59,7 +59,7 @@ export default class AgentCreate extends SfCommand<AgentCreateResult> {
 
     mso.goto(jsonParsingStage);
     const agentConfig = {
-      ...(JSON.parse(fs.readFileSync(flags['job-spec'], 'utf8')) as AgentCreateConfig),
+      ...(JSON.parse(fs.readFileSync(flags.spec, 'utf8')) as AgentCreateConfig),
       name: flags.name,
     };
 


### PR DESCRIPTION
### What does this PR do?

changes `agent create --job-spec` to `--spec` to match `agent create spec` command

### What issues does this PR fix or reference?
