### PR TITLE
W-17832744 remove target-org

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -49,8 +49,8 @@
     "alias": [],
     "command": "agent:generate:template",
     "flagAliases": [],
-    "flagChars": ["f", "o"],
-    "flags": ["agent-file", "agent-version", "api-version", "flags-dir", "json", "target-org"],
+    "flagChars": ["f"],
+    "flags": ["agent-file", "agent-version", "api-version", "flags-dir", "json"],
     "plugin": "@salesforce/plugin-agent"
   },
   {

--- a/src/commands/agent/generate/template.ts
+++ b/src/commands/agent/generate/template.ts
@@ -57,7 +57,6 @@ export default class AgentGenerateTemplate extends SfCommand<AgentGenerateTempla
   public static readonly requiresProject = true;
 
   public static readonly flags = {
-    'target-org': Flags.requiredOrg(),
     'api-version': Flags.orgApiVersion(),
     'agent-version': Flags.integer({
       summary: messages.getMessage('flags.agent-version.summary'),


### PR DESCRIPTION
### What does this PR do?
Removes the target-org from the `agent generate template` command. It only needs to look at local files.

### What issues does this PR fix or reference?
[@W-17832744@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-17832744)
