### PR TITLE
fix: change table column title to API name, was already displaying it W-17875213

### DIFF
--- a/src/commands/agent/test/list.ts
+++ b/src/commands/agent/test/list.ts
@@ -33,7 +33,7 @@ export default class AgentTestList extends SfCommand<AgentTestListResult> {
     this.table({
       data: results,
       columns: [
-        { key: 'fullName', name: 'Name' },
+        { key: 'fullName', name: 'API Name' },
         { key: 'id', name: 'Id' },
         { key: 'createdDate', name: 'Created Date' },
       ],


### PR DESCRIPTION
### What does this PR do?

changes the table column title to "API Name"
```bash
 ➜  sf agent list test                               
Warning: This command is currently in beta. Any aspect of this command can change without advanced notice. Don't use beta commands in your scripts.
┌───────────────────────┬────────────────────┬──────────────────────────┐
│ Name                  │ Id                 │ Created Date             │
├───────────────────────┼────────────────────┼──────────────────────────┤
│ Local_Info_Agent_Test │ 4KCed000000aTMrGAM │ 2025-02-13T22:21:43.000Z │
```

```bash
 ➜  sf agent list test                               

Warning: This command is currently in beta. Any aspect of this command can change without advanced notice. Don't use beta commands in your scripts.
┌───────────────────────┬────────────────────┬──────────────────────────┐
│ API Name                  │ Id                 │ Created Date             │
├───────────────────────┼────────────────────┼──────────────────────────┤
│ Local_Info_Agent_Test │ 4KCed000000aTMrGAM │ 2025-02-13T22:21:43.000Z │
```

### What issues does this PR fix or reference?
@W-17875213@