### PR TITLE
fix: allow no actions in generate test-spec W-17891598

### DIFF
--- a/src/commands/agent/generate/test-spec.ts
+++ b/src/commands/agent/generate/test-spec.ts
@@ -74,12 +74,28 @@ async function promptForTestCase(genAiPlugins: Record<string, string>, genAiFunc
     actions = castArray(parsed.GenAiPlugin.genAiFunctions ?? []).map((f) => f.functionName);
   }
 
-  const expectedActions = await checkbox<string>({
-    message: 'Expected action(s)',
-    choices: [...actions, ...genAiFunctions],
-    theme,
-    required: true,
-  });
+  const expectedActions = (
+    await checkbox<string | null>({
+      message: 'Expected action(s)',
+      choices: [
+        ...actions.map((a) => ({ name: a, value: a })),
+        ...genAiFunctions.map((f) => ({ name: f, value: f })),
+        { name: 'No Actions', value: null },
+      ],
+      theme,
+      validate: (choices) => {
+        if (choices.find((c) => c.name === 'No Actions')?.checked && choices.length > 1) {
+          // "no actions" selected, and other actions selected
+          // returns as the error message to the user
+          return 'Cannot select "No Actions" and other Actions';
+        }
+        return true;
+      },
+      required: true,
+    })
+  )
+    // remove the 'No Actions', null entry to produce "expectedActions: []" in spec.yaml
+    .filter((f) => f !== null);
 
   const expectedOutcome = await input({
     message: 'Expected outcome',

--- a/src/commands/agent/generate/test-spec.ts
+++ b/src/commands/agent/generate/test-spec.ts
@@ -78,9 +78,8 @@ async function promptForTestCase(genAiPlugins: Record<string, string>, genAiFunc
     await checkbox<string | null>({
       message: 'Expected action(s)',
       choices: [
-        ...actions.map((a) => ({ name: a, value: a })),
-        ...genAiFunctions.map((f) => ({ name: f, value: f })),
         { name: 'No Actions', value: null },
+        ...actions.concat(genAiFunctions).map((a) => ({ name: a, value: a })),
       ],
       theme,
       validate: (choices) => {


### PR DESCRIPTION
### What does this PR do?

allows the users to select "no expected actions" for the test-spec
generates `"expectedActions: []"` in .yaml

### What issues does this PR fix or reference?
@W-17891598@