### PR TITLE
W-17906887 add role to BotTemplate

### DIFF
--- a/src/commands/agent/generate/template.ts
+++ b/src/commands/agent/generate/template.ts
@@ -31,6 +31,7 @@ type BotTemplateExt = {
     botDialogGroups?: BotDialogGroup[];
     conversationGoals?: ConversationDefinitionGoal[];
     conversationVariables?: ConversationVariable[];
+    role?: string;
   };
 };
 
@@ -39,7 +40,7 @@ type BotExt = {
 };
 
 type BotVersionExt = {
-  BotVersion: BotVersion;
+  BotVersion: BotVersion & { role?: string };
 };
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
@@ -131,7 +132,7 @@ const convertBotToBotTemplate = (
   botFilePath: string
 ): BotTemplateExt => {
   const entryDialog = botVersionJson.BotVersion.entryDialog;
-  const { conversationSystemDialogs } = botVersionJson.BotVersion;
+  const { conversationSystemDialogs, role } = botVersionJson.BotVersion;
 
   // We need to pull the botDialog from the BotVersion file that matches the entryDialog
   // This will be added to the BotTemplate
@@ -169,6 +170,7 @@ const convertBotToBotTemplate = (
         entryDialogJson,
       ],
       conversationSystemDialogs,
+      role,
       entryDialog,
       mlDomain,
       ...bot.Bot,


### PR DESCRIPTION
### What does this PR do?
Pulls the `role` from `BotVersion` and adds it to the generated `BotTemplate`

### What issues does this PR fix or reference?
[@W-17906887@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-17906887)

Visual QA:
<img width="1028" alt="Screenshot 2025-02-25 at 11 19 00 AM" src="https://github.com/user-attachments/assets/a16e219e-339c-47ef-9dbd-1c7e4469b7ff" />
