### PR TITLE
Wr/resume finished output W-17919374

### DIFF
--- a/schemas/agent-test-resume.json
+++ b/schemas/agent-test-resume.json
@@ -3,52 +3,35 @@
   "$ref": "#/definitions/AgentTestRunResult",
   "definitions": {
     "AgentTestRunResult": {
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "runId": {
-              "type": "string"
-            },
-            "status": {
-              "type": "string"
-            }
-          },
-          "required": ["runId", "status"],
-          "additionalProperties": false
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/TestStatus"
         },
-        {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "status": {
-              "$ref": "#/definitions/TestStatus"
-            },
-            "runId": {
-              "type": "string"
-            },
-            "startTime": {
-              "type": "string"
-            },
-            "endTime": {
-              "type": "string"
-            },
-            "errorMessage": {
-              "type": "string"
-            },
-            "subjectName": {
-              "type": "string"
-            },
-            "testCases": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/TestCaseResult"
-              }
-            }
-          },
-          "required": ["runId", "startTime", "status", "subjectName", "testCases"]
+        "runId": {
+          "type": "string"
+        },
+        "startTime": {
+          "type": "string"
+        },
+        "endTime": {
+          "type": "string"
+        },
+        "errorMessage": {
+          "type": "string"
+        },
+        "subjectName": {
+          "type": "string"
+        },
+        "testCases": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TestCaseResult"
+          }
         }
-      ]
+      },
+      "required": ["runId", "status"]
     },
     "TestStatus": {
       "type": "string",

--- a/schemas/agent-test-resume.json
+++ b/schemas/agent-test-resume.json
@@ -3,35 +3,70 @@
   "$ref": "#/definitions/AgentTestRunResult",
   "definitions": {
     "AgentTestRunResult": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "status": {
-          "$ref": "#/definitions/TestStatus"
+      "anyOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "$ref": "#/definitions/TestStatus"
+            },
+            "runId": {
+              "type": "string"
+            },
+            "startTime": {
+              "type": "string"
+            },
+            "endTime": {
+              "type": "string"
+            },
+            "errorMessage": {
+              "type": "string"
+            },
+            "subjectName": {
+              "type": "string"
+            },
+            "testCases": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/TestCaseResult"
+              }
+            }
+          },
+          "required": ["runId", "status"]
         },
-        "runId": {
-          "type": "string"
-        },
-        "startTime": {
-          "type": "string"
-        },
-        "endTime": {
-          "type": "string"
-        },
-        "errorMessage": {
-          "type": "string"
-        },
-        "subjectName": {
-          "type": "string"
-        },
-        "testCases": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/TestCaseResult"
-          }
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "$ref": "#/definitions/TestStatus"
+            },
+            "runId": {
+              "type": "string"
+            },
+            "startTime": {
+              "type": "string"
+            },
+            "endTime": {
+              "type": "string"
+            },
+            "errorMessage": {
+              "type": "string"
+            },
+            "subjectName": {
+              "type": "string"
+            },
+            "testCases": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/TestCaseResult"
+              }
+            }
+          },
+          "required": ["runId", "startTime", "status", "subjectName", "testCases"]
         }
-      },
-      "required": ["runId", "status"]
+      ]
     },
     "TestStatus": {
       "type": "string",

--- a/schemas/agent-test-resume.json
+++ b/schemas/agent-test-resume.json
@@ -1,18 +1,163 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$ref": "#/definitions/AgentTestResumeResult",
+  "$ref": "#/definitions/AgentTestRunResult",
   "definitions": {
-    "AgentTestResumeResult": {
+    "AgentTestRunResult": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "runId": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            }
+          },
+          "required": ["runId", "status"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "$ref": "#/definitions/TestStatus"
+            },
+            "runId": {
+              "type": "string"
+            },
+            "startTime": {
+              "type": "string"
+            },
+            "endTime": {
+              "type": "string"
+            },
+            "errorMessage": {
+              "type": "string"
+            },
+            "subjectName": {
+              "type": "string"
+            },
+            "testCases": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/TestCaseResult"
+              }
+            }
+          },
+          "required": ["runId", "startTime", "status", "subjectName", "testCases"]
+        }
+      ]
+    },
+    "TestStatus": {
+      "type": "string",
+      "enum": ["NEW", "IN_PROGRESS", "COMPLETED", "ERROR", "TERMINATED"]
+    },
+    "TestCaseResult": {
       "type": "object",
       "properties": {
-        "runId": {
+        "status": {
+          "$ref": "#/definitions/TestStatus"
+        },
+        "startTime": {
           "type": "string"
         },
-        "status": {
+        "endTime": {
           "type": "string"
+        },
+        "inputs": {
+          "type": "object",
+          "properties": {
+            "utterance": {
+              "type": "string"
+            }
+          },
+          "required": ["utterance"],
+          "additionalProperties": false
+        },
+        "generatedData": {
+          "type": "object",
+          "properties": {
+            "actionsSequence": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "outcome": {
+              "type": "string"
+            },
+            "topic": {
+              "type": "string"
+            }
+          },
+          "required": ["actionsSequence", "outcome", "topic"],
+          "additionalProperties": false
+        },
+        "testResults": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "actualValue": {
+                "type": "string"
+              },
+              "expectedValue": {
+                "type": "string"
+              },
+              "score": {
+                "type": "number"
+              },
+              "result": {
+                "type": "string",
+                "enum": ["PASS", "FAILURE"]
+              },
+              "metricLabel": {
+                "type": "string",
+                "enum": ["Accuracy", "Precision"]
+              },
+              "metricExplainability": {
+                "type": "string"
+              },
+              "status": {
+                "$ref": "#/definitions/TestStatus"
+              },
+              "startTime": {
+                "type": "string"
+              },
+              "endTime": {
+                "type": "string"
+              },
+              "errorCode": {
+                "type": "string"
+              },
+              "errorMessage": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "actualValue",
+              "expectedValue",
+              "score",
+              "result",
+              "metricLabel",
+              "metricExplainability",
+              "status",
+              "startTime"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "testNumber": {
+          "type": "number"
         }
       },
-      "required": ["runId", "status"],
+      "required": ["status", "startTime", "inputs", "generatedData", "testResults", "testNumber"],
       "additionalProperties": false
     }
   }

--- a/schemas/agent-test-run.json
+++ b/schemas/agent-test-run.json
@@ -3,52 +3,35 @@
   "$ref": "#/definitions/AgentTestRunResult",
   "definitions": {
     "AgentTestRunResult": {
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "runId": {
-              "type": "string"
-            },
-            "status": {
-              "type": "string"
-            }
-          },
-          "required": ["runId", "status"],
-          "additionalProperties": false
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/TestStatus"
         },
-        {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "status": {
-              "$ref": "#/definitions/TestStatus"
-            },
-            "runId": {
-              "type": "string"
-            },
-            "startTime": {
-              "type": "string"
-            },
-            "endTime": {
-              "type": "string"
-            },
-            "errorMessage": {
-              "type": "string"
-            },
-            "subjectName": {
-              "type": "string"
-            },
-            "testCases": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/TestCaseResult"
-              }
-            }
-          },
-          "required": ["runId", "startTime", "status", "subjectName", "testCases"]
+        "runId": {
+          "type": "string"
+        },
+        "startTime": {
+          "type": "string"
+        },
+        "endTime": {
+          "type": "string"
+        },
+        "errorMessage": {
+          "type": "string"
+        },
+        "subjectName": {
+          "type": "string"
+        },
+        "testCases": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TestCaseResult"
+          }
         }
-      ]
+      },
+      "required": ["runId", "status"]
     },
     "TestStatus": {
       "type": "string",

--- a/schemas/agent-test-run.json
+++ b/schemas/agent-test-run.json
@@ -3,35 +3,70 @@
   "$ref": "#/definitions/AgentTestRunResult",
   "definitions": {
     "AgentTestRunResult": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "status": {
-          "$ref": "#/definitions/TestStatus"
+      "anyOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "$ref": "#/definitions/TestStatus"
+            },
+            "runId": {
+              "type": "string"
+            },
+            "startTime": {
+              "type": "string"
+            },
+            "endTime": {
+              "type": "string"
+            },
+            "errorMessage": {
+              "type": "string"
+            },
+            "subjectName": {
+              "type": "string"
+            },
+            "testCases": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/TestCaseResult"
+              }
+            }
+          },
+          "required": ["runId", "status"]
         },
-        "runId": {
-          "type": "string"
-        },
-        "startTime": {
-          "type": "string"
-        },
-        "endTime": {
-          "type": "string"
-        },
-        "errorMessage": {
-          "type": "string"
-        },
-        "subjectName": {
-          "type": "string"
-        },
-        "testCases": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/TestCaseResult"
-          }
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "$ref": "#/definitions/TestStatus"
+            },
+            "runId": {
+              "type": "string"
+            },
+            "startTime": {
+              "type": "string"
+            },
+            "endTime": {
+              "type": "string"
+            },
+            "errorMessage": {
+              "type": "string"
+            },
+            "subjectName": {
+              "type": "string"
+            },
+            "testCases": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/TestCaseResult"
+              }
+            }
+          },
+          "required": ["runId", "startTime", "status", "subjectName", "testCases"]
         }
-      },
-      "required": ["runId", "status"]
+      ]
     },
     "TestStatus": {
       "type": "string",

--- a/schemas/agent-test-run.json
+++ b/schemas/agent-test-run.json
@@ -3,16 +3,161 @@
   "$ref": "#/definitions/AgentTestRunResult",
   "definitions": {
     "AgentTestRunResult": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "runId": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            }
+          },
+          "required": ["runId", "status"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "$ref": "#/definitions/TestStatus"
+            },
+            "runId": {
+              "type": "string"
+            },
+            "startTime": {
+              "type": "string"
+            },
+            "endTime": {
+              "type": "string"
+            },
+            "errorMessage": {
+              "type": "string"
+            },
+            "subjectName": {
+              "type": "string"
+            },
+            "testCases": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/TestCaseResult"
+              }
+            }
+          },
+          "required": ["runId", "startTime", "status", "subjectName", "testCases"]
+        }
+      ]
+    },
+    "TestStatus": {
+      "type": "string",
+      "enum": ["NEW", "IN_PROGRESS", "COMPLETED", "ERROR", "TERMINATED"]
+    },
+    "TestCaseResult": {
       "type": "object",
       "properties": {
-        "runId": {
+        "status": {
+          "$ref": "#/definitions/TestStatus"
+        },
+        "startTime": {
           "type": "string"
         },
-        "status": {
+        "endTime": {
           "type": "string"
+        },
+        "inputs": {
+          "type": "object",
+          "properties": {
+            "utterance": {
+              "type": "string"
+            }
+          },
+          "required": ["utterance"],
+          "additionalProperties": false
+        },
+        "generatedData": {
+          "type": "object",
+          "properties": {
+            "actionsSequence": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "outcome": {
+              "type": "string"
+            },
+            "topic": {
+              "type": "string"
+            }
+          },
+          "required": ["actionsSequence", "outcome", "topic"],
+          "additionalProperties": false
+        },
+        "testResults": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "actualValue": {
+                "type": "string"
+              },
+              "expectedValue": {
+                "type": "string"
+              },
+              "score": {
+                "type": "number"
+              },
+              "result": {
+                "type": "string",
+                "enum": ["PASS", "FAILURE"]
+              },
+              "metricLabel": {
+                "type": "string",
+                "enum": ["Accuracy", "Precision"]
+              },
+              "metricExplainability": {
+                "type": "string"
+              },
+              "status": {
+                "$ref": "#/definitions/TestStatus"
+              },
+              "startTime": {
+                "type": "string"
+              },
+              "endTime": {
+                "type": "string"
+              },
+              "errorCode": {
+                "type": "string"
+              },
+              "errorMessage": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "actualValue",
+              "expectedValue",
+              "score",
+              "result",
+              "metricLabel",
+              "metricExplainability",
+              "status",
+              "startTime"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "testNumber": {
+          "type": "number"
         }
       },
-      "required": ["runId", "status"],
+      "required": ["status", "startTime", "inputs", "generatedData", "testResults", "testNumber"],
       "additionalProperties": false
     }
   }

--- a/src/commands/agent/test/resume.ts
+++ b/src/commands/agent/test/resume.ts
@@ -72,6 +72,6 @@ export default class AgentTestResume extends SfCommand<AgentTestRunResult> {
       outputDir: flags['output-dir'],
     });
 
-    return { runId, status: 'COMPLETED', ...response };
+    return { ...response!, runId, status: 'COMPLETED' };
   }
 }

--- a/src/commands/agent/test/resume.ts
+++ b/src/commands/agent/test/resume.ts
@@ -10,18 +10,13 @@ import { Messages } from '@salesforce/core';
 import { AgentTester } from '@salesforce/agents';
 import { AgentTestCache } from '../../../agentTestCache.js';
 import { TestStages } from '../../../testStages.js';
-import { resultFormatFlag, testOutputDirFlag } from '../../../flags.js';
+import { AgentTestRunResult, resultFormatFlag, testOutputDirFlag } from '../../../flags.js';
 import { handleTestResults } from '../../../handleTestResults.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-agent', 'agent.test.resume');
 
-export type AgentTestResumeResult = {
-  runId: string;
-  status: string;
-};
-
-export default class AgentTestResume extends SfCommand<AgentTestResumeResult> {
+export default class AgentTestResume extends SfCommand<AgentTestRunResult> {
   public static readonly summary = messages.getMessage('summary');
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
@@ -51,7 +46,7 @@ export default class AgentTestResume extends SfCommand<AgentTestResumeResult> {
     'output-dir': testOutputDirFlag(),
   };
 
-  public async run(): Promise<AgentTestResumeResult> {
+  public async run(): Promise<AgentTestRunResult> {
     const { flags } = await this.parse(AgentTestResume);
 
     const agentTestCache = await AgentTestCache.create();
@@ -77,9 +72,8 @@ export default class AgentTestResume extends SfCommand<AgentTestResumeResult> {
       outputDir: flags['output-dir'],
     });
 
-    return {
-      status: 'COMPLETED',
-      runId,
-    };
+    return completed && response
+      ? { ...response, ...{ status: 'COMPLETED', runId } }
+      : { runId, status: 'IN_PROGRESS' };
   }
 }

--- a/src/commands/agent/test/resume.ts
+++ b/src/commands/agent/test/resume.ts
@@ -72,8 +72,6 @@ export default class AgentTestResume extends SfCommand<AgentTestRunResult> {
       outputDir: flags['output-dir'],
     });
 
-    return completed && response
-      ? { ...response, ...{ status: 'COMPLETED', runId } }
-      : { runId, status: 'IN_PROGRESS' };
+    return { runId, status: 'COMPLETED', ...response };
   }
 }

--- a/src/commands/agent/test/run.ts
+++ b/src/commands/agent/test/run.ts
@@ -101,12 +101,7 @@ export default class AgentTestRun extends SfCommand<AgentTestRunResult> {
         outputDir: flags['output-dir'],
       });
 
-      return detailsResponse
-        ? { ...detailsResponse, ...{ status: 'COMPLETED', runId: response.runId } }
-        : {
-            status: 'IN_PROGRESS',
-            runId: response.runId,
-          };
+      return { ...detailsResponse, ...{ status: 'COMPLETED', runId: response.runId } };
     } else {
       this.mso.stop();
       this.log(

--- a/src/commands/agent/test/run.ts
+++ b/src/commands/agent/test/run.ts
@@ -11,6 +11,7 @@ import { AgentTester } from '@salesforce/agents';
 import { colorize } from '@oclif/core/ux';
 import { CLIError } from '@oclif/core/errors';
 import {
+  AgentTestRunResult,
   FlaggablePrompt,
   makeFlags,
   promptForAiEvaluationDefinitionApiName,
@@ -23,12 +24,6 @@ import { handleTestResults } from '../../../handleTestResults.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-agent', 'agent.test.run');
-
-// TODO: this should include details and status
-export type AgentTestRunResult = {
-  runId: string;
-  status: string;
-};
 
 const FLAGGABLE_PROMPTS = {
   'api-name': {
@@ -106,10 +101,12 @@ export default class AgentTestRun extends SfCommand<AgentTestRunResult> {
         outputDir: flags['output-dir'],
       });
 
-      return {
-        status: 'COMPLETED',
-        runId: response.runId,
-      };
+      return detailsResponse
+        ? { ...detailsResponse, ...{ status: 'COMPLETED', runId: response.runId } }
+        : {
+            status: 'IN_PROGRESS',
+            runId: response.runId,
+          };
     } else {
       this.mso.stop();
       this.log(
@@ -117,7 +114,7 @@ export default class AgentTestRun extends SfCommand<AgentTestRunResult> {
       );
     }
 
-    return response;
+    return { status: 'IN_PROGRESS', runId: response.runId };
   }
 
   protected catch(error: Error | SfError | CLIError): Promise<never> {

--- a/src/commands/agent/test/run.ts
+++ b/src/commands/agent/test/run.ts
@@ -101,7 +101,7 @@ export default class AgentTestRun extends SfCommand<AgentTestRunResult> {
         outputDir: flags['output-dir'],
       });
 
-      return { ...detailsResponse, ...{ status: 'COMPLETED', runId: response.runId } };
+      return { ...detailsResponse!, status: 'COMPLETED', runId: response.runId };
     } else {
       this.mso.stop();
       this.log(

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -13,11 +13,18 @@ import { Connection, Messages, SfError } from '@salesforce/core';
 import { camelCaseToTitleCase } from '@salesforce/kit';
 import { select, input as inquirerInput } from '@inquirer/prompts';
 import autocomplete from 'inquirer-autocomplete-standalone';
-import { AgentTester } from '@salesforce/agents';
+import { AgentTester, AgentTestResultsResponse } from '@salesforce/agents';
 import { theme } from './inquirer-theme.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-agent', 'shared');
+
+export type AgentTestRunResult =
+  | {
+      runId: string;
+      status: string;
+    }
+  | (AgentTestResultsResponse & { status: 'COMPLETED'; runId: string });
 
 export type FlaggablePrompt = {
   message: string;

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -19,12 +19,7 @@ import { theme } from './inquirer-theme.js';
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-agent', 'shared');
 
-export type AgentTestRunResult =
-  | {
-      runId: string;
-      status: string;
-    }
-  | (AgentTestResultsResponse & { status: 'COMPLETED'; runId: string });
+export type AgentTestRunResult = Partial<AgentTestResultsResponse> & { status: string; runId: string };
 
 export type FlaggablePrompt = {
   message: string;

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -15,11 +15,14 @@ import { select, input as inquirerInput } from '@inquirer/prompts';
 import autocomplete from 'inquirer-autocomplete-standalone';
 import { AgentTester, AgentTestResultsResponse } from '@salesforce/agents';
 import { theme } from './inquirer-theme.js';
+import { AgentTestResultsResult } from './commands/agent/test/results.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-agent', 'shared');
 
-export type AgentTestRunResult = Partial<AgentTestResultsResponse> & { status: string; runId: string };
+export type AgentTestRunResult =
+  | (Partial<AgentTestResultsResponse> & { status: 'NEW' | 'IN_PROGRESS' | 'ERROR' | 'TERMINATED'; runId: string })
+  | (AgentTestResultsResult & { status: 'COMPLETED'; runId: string });
 
 export type FlaggablePrompt = {
   message: string;

--- a/test/commands/agent/test/cancel.nut.ts
+++ b/test/commands/agent/test/cancel.nut.ts
@@ -7,9 +7,9 @@
 import { resolve } from 'node:path';
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
 import { expect } from 'chai';
-import { AgentTestRunResult } from '../../../../src/commands/agent/test/run.js';
 import { AgentTestCancelResult } from '../../../../src/commands/agent/test/cancel.js';
 import { AgentTestCache } from '../../../../src/agentTestCache.js';
+import type { AgentTestRunResult } from '../../../../src/flags.js';
 
 describe('agent test cancel NUTs', () => {
   let session: TestSession;

--- a/test/commands/agent/test/results.nut.ts
+++ b/test/commands/agent/test/results.nut.ts
@@ -7,9 +7,9 @@
 import { resolve } from 'node:path';
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
 import { expect } from 'chai';
-import { AgentTestRunResult } from '../../../../src/commands/agent/test/run.js';
 import { AgentTestResultsResult } from '../../../../src/commands/agent/test/results.js';
 import { AgentTestCache } from '../../../../src/agentTestCache.js';
+import type { AgentTestRunResult } from '../../../../src/flags.js';
 
 describe('agent test results NUTs', () => {
   let session: TestSession;

--- a/test/commands/agent/test/resume.nut.ts
+++ b/test/commands/agent/test/resume.nut.ts
@@ -7,9 +7,8 @@
 import { resolve } from 'node:path';
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
 import { expect } from 'chai';
-import { AgentTestRunResult } from '../../../../src/commands/agent/test/run.js';
-import { AgentTestResumeResult } from '../../../../src/commands/agent/test/resume.js';
 import { AgentTestCache } from '../../../../src/agentTestCache.js';
+import type { AgentTestRunResult } from '../../../../src/flags.js';
 
 describe('agent test resume NUTs', () => {
   let session: TestSession;
@@ -37,7 +36,7 @@ describe('agent test resume NUTs', () => {
 
     expect(runResult?.result.runId).to.be.ok;
 
-    const output = execCmd<AgentTestResumeResult>(
+    const output = execCmd<AgentTestRunResult>(
       `agent test resume --job-id ${runResult?.result.runId} --target-org ${session.hubOrg.username} --json`,
       {
         ensureExitCode: 0,

--- a/test/commands/agent/test/run.nut.ts
+++ b/test/commands/agent/test/run.nut.ts
@@ -7,8 +7,8 @@
 import { resolve } from 'node:path';
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
 import { expect } from 'chai';
-import { AgentTestRunResult } from '../../../../src/commands/agent/test/run.js';
 import { AgentTestCache } from '../../../../src/agentTestCache.js';
+import type { AgentTestRunResult } from '../../../../src/flags.js';
 
 describe('agent test run NUTs', () => {
   let session: TestSession;


### PR DESCRIPTION
### What does this PR do?

changes `--json` output for `resume`/`start` to include test data if tests finished in wait time

### What issues does this PR fix or reference?
@W-17919374@