### PR TITLE
fix: use generateApiName from core W-18394863

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@inquirer/prompts": "^7.2.0",
     "@oclif/core": "^4",
     "@oclif/multi-stage-output": "^0.7.12",
-    "@salesforce/agents": "^0.14.8",
+    "@salesforce/agents": "^0.14.9",
     "@salesforce/core": "^8.10.1",
     "@salesforce/kit": "^3.2.3",
     "@salesforce/sf-plugins-core": "^12.2.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@oclif/core": "^4",
     "@oclif/multi-stage-output": "^0.7.12",
     "@salesforce/agents": "^0.14.8",
-    "@salesforce/core": "^8.9.1",
+    "@salesforce/core": "^8.10.1",
     "@salesforce/kit": "^3.2.3",
     "@salesforce/sf-plugins-core": "^12.2.0",
     "@salesforce/source-deploy-retrieve": "^12.19.3",

--- a/src/commands/agent/create.ts
+++ b/src/commands/agent/create.ts
@@ -8,7 +8,7 @@ import { resolve } from 'node:path';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import YAML from 'yaml';
 import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
-import { Lifecycle, Messages, SfProject } from '@salesforce/core';
+import { Lifecycle, Messages, SfProject, generateApiName } from '@salesforce/core';
 import { MultiStageOutput } from '@oclif/multi-stage-output';
 import { input as inquirerInput } from '@inquirer/prompts';
 import { colorize } from '@oclif/core/ux';
@@ -18,7 +18,6 @@ import {
   AgentCreateConfig,
   AgentCreateLifecycleStages,
   AgentCreateResponse,
-  generateAgentApiName,
 } from '@salesforce/agents';
 import {
   FlaggablePrompt,
@@ -129,7 +128,7 @@ export default class AgentCreate extends SfCommand<AgentCreateResult> {
     const agentName = flags['agent-name'] ?? (await promptForFlag(FLAGGABLE_PROMPTS['agent-name']));
     let agentApiName = flags['agent-api-name'];
     if (!agentApiName) {
-      agentApiName = generateAgentApiName(agentName);
+      agentApiName = generateApiName(agentName);
       const promptedValue = await inquirerInput({
         message: messages.getMessage('flags.agent-api-name.prompt'),
         validate: FLAGGABLE_PROMPTS['agent-api-name'].validate,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1471,10 +1471,10 @@
     strip-ansi "6.0.1"
     ts-retry-promise "^0.8.1"
 
-"@salesforce/core@^8.10.0", "@salesforce/core@^8.5.1", "@salesforce/core@^8.8.0", "@salesforce/core@^8.8.2", "@salesforce/core@^8.8.5", "@salesforce/core@^8.8.7", "@salesforce/core@^8.9.1":
-  version "8.10.0"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.10.0.tgz#017fe618b1dd086298d1133a6ed0f509d56ea495"
-  integrity sha512-gStIzB8wPjjwyKZCK8eSfwkLiv9h9qzP64b51U5THBskEjm6Sw6ZyWqZmCzA85FEZ/IM/n1nh4e3R9JoG6Z6mA==
+"@salesforce/core@^8.10.0", "@salesforce/core@^8.10.1", "@salesforce/core@^8.5.1", "@salesforce/core@^8.8.0", "@salesforce/core@^8.8.2", "@salesforce/core@^8.8.5", "@salesforce/core@^8.8.7", "@salesforce/core@^8.9.1":
+  version "8.10.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.10.1.tgz#d80283ac9515a5e38677c1aadd4ab91a00866f0d"
+  integrity sha512-2Pk8MUlO9HTUo6K9bpFxLyc7KUxuIIgmGrFliCQJiUW2N85uvMdB8F+WJD2b8ZOH+6bQ575qynmJlbKmfcLAtQ==
   dependencies:
     "@jsforce/jsforce-node" "^3.7.0"
     "@salesforce/kit" "^3.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1443,12 +1443,12 @@
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
-"@salesforce/agents@^0.14.8":
-  version "0.14.8"
-  resolved "https://registry.yarnpkg.com/@salesforce/agents/-/agents-0.14.8.tgz#f0da5f8981fede6761c7e6ac054af639c0831d9e"
-  integrity sha512-YdgUZwvfUopbKtdoJQWmqV4HFbdA6AgxBMYlzgqVy7E7DBwwNgrEMrgxbENivhoQanbk6PaZQP9tvXvKv+DweQ==
+"@salesforce/agents@^0.14.9":
+  version "0.14.9"
+  resolved "https://registry.yarnpkg.com/@salesforce/agents/-/agents-0.14.9.tgz#e03d2ef10bad08862c8da20d394c5fd4a4a2a584"
+  integrity sha512-soBN0aC/scHic3sLhmMe9Qm5IOyw9qDqbsxrpW3Rof7Bl39rq+Osq+0UN8bjbk3/IYD+tiaJmF7sY014ufFECQ==
   dependencies:
-    "@salesforce/core" "^8.10.0"
+    "@salesforce/core" "^8.10.1"
     "@salesforce/kit" "^3.2.3"
     "@salesforce/source-deploy-retrieve" "^12.19.3"
     fast-xml-parser "^4.5.3"
@@ -1471,7 +1471,7 @@
     strip-ansi "6.0.1"
     ts-retry-promise "^0.8.1"
 
-"@salesforce/core@^8.10.0", "@salesforce/core@^8.10.1", "@salesforce/core@^8.5.1", "@salesforce/core@^8.8.0", "@salesforce/core@^8.8.2", "@salesforce/core@^8.8.5", "@salesforce/core@^8.8.7", "@salesforce/core@^8.9.1":
+"@salesforce/core@^8.10.1", "@salesforce/core@^8.5.1", "@salesforce/core@^8.8.0", "@salesforce/core@^8.8.2", "@salesforce/core@^8.8.5", "@salesforce/core@^8.8.7", "@salesforce/core@^8.9.1":
   version "8.10.1"
   resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.10.1.tgz#d80283ac9515a5e38677c1aadd4ab91a00866f0d"
   integrity sha512-2Pk8MUlO9HTUo6K9bpFxLyc7KUxuIIgmGrFliCQJiUW2N85uvMdB8F+WJD2b8ZOH+6bQ575qynmJlbKmfcLAtQ==


### PR DESCRIPTION
### What does this PR do?
uses `generateApiName` from core now
requires: https://github.com/forcedotcom/sfdx-core/pull/1183
### What issues does this PR fix or reference?
@W-18394863@