### PR TITLE
feat: add agent preview debug mode - W-18417013

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -55,8 +55,8 @@
     "alias": [],
     "command": "agent:preview",
     "flagAliases": [],
-    "flagChars": ["a", "d", "n", "o"],
-    "flags": ["api-name", "api-version", "connected-app-user", "flags-dir", "output-dir", "target-org"],
+    "flagChars": ["a", "d", "n", "o", "x"],
+    "flags": ["apex-debug", "api-name", "api-version", "connected-app-user", "flags-dir", "output-dir", "target-org"],
     "plugin": "@salesforce/plugin-agent"
   },
   {

--- a/messages/agent.preview.md
+++ b/messages/agent.preview.md
@@ -52,7 +52,7 @@ Directory where conversation transcripts are saved.
 
 # flags.apex-debug.summary
 
-Enable apex debug logging during agent conversation.
+Enable Apex debug logging during the agent preview conversation.
 
 # examples
 

--- a/messages/agent.preview.md
+++ b/messages/agent.preview.md
@@ -13,7 +13,8 @@ When the session concludes, the command asks if you want to save the API respons
 Find the agent's API name in its main details page in your org's Agent page in Setup.
 
 Before you use this command, you must complete these steps:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+```
 
 1. Create a connected app in your org as described in the "Create a Connected App" section here: https://developer.salesforce.com/docs/einstein/genai/guide/agent-api-get-started.html#create-a-connected-app. Do these four additional steps:
 
@@ -51,6 +52,10 @@ Username or alias of the connected app user that's configured with web-based acc
 
 Directory where conversation transcripts are saved.
 
+# flags.apex-debug.summary
+
+Enable apex debug logging during agent conversation.
+
 # examples
 
 - Interact with an agent with API name "Resort_Manager" in the org with alias "my-org". Connect to your agent using the alias "my-agent-user"; this alias must point to the username who is authorized using the Web server flow:
@@ -60,3 +65,4 @@ Directory where conversation transcripts are saved.
 - Same as the preceding example, but this time save the conversation transcripts to the "./transcripts/my-preview" directory rather than the default "./temp/agent-preview":
 
   <%= config.bin %> <%= command.id %> --api-name "Resort_Manager" --target-org my-org --connected-app-user my-agent-user --output-dir "transcripts/my-preview"
+```

--- a/messages/agent.preview.md
+++ b/messages/agent.preview.md
@@ -63,4 +63,3 @@ Enable apex debug logging during agent conversation.
 - Same as the preceding example, but this time save the conversation transcripts to the "./transcripts/my-preview" directory rather than the default "./temp/agent-preview":
 
   <%= config.bin %> <%= command.id %> --api-name "Resort_Manager" --target-org my-org --connected-app-user my-agent-user --output-dir "transcripts/my-preview"
-```

--- a/messages/agent.preview.md
+++ b/messages/agent.preview.md
@@ -14,8 +14,6 @@ Find the agent's API name in its main details page in your org's Agent page in S
 
 Before you use this command, you must complete these steps:
 
-```
-
 1. Create a connected app in your org as described in the "Create a Connected App" section here: https://developer.salesforce.com/docs/einstein/genai/guide/agent-api-get-started.html#create-a-connected-app. Do these four additional steps:
 
    a. When specifying the connected app's Callback URL, add this second callback URL on a new line: "http://localhost:1717/OauthRedirect".

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@inquirer/prompts": "^7.2.0",
     "@oclif/core": "^4",
     "@oclif/multi-stage-output": "^0.7.12",
-    "@salesforce/agents": "0.14.11",
+    "@salesforce/agents": "0.14.14-dev.0",
     "@salesforce/core": "^8.10.2",
     "@salesforce/kit": "^3.2.3",
     "@salesforce/sf-plugins-core": "^12.2.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@inquirer/prompts": "^7.2.0",
     "@oclif/core": "^4",
     "@oclif/multi-stage-output": "^0.7.12",
-    "@salesforce/agents": "0.14.14-dev.0",
+    "@salesforce/agents": "0.15.0",
     "@salesforce/core": "^8.10.2",
     "@salesforce/kit": "^3.2.3",
     "@salesforce/sf-plugins-core": "^12.2.0",

--- a/src/commands/agent/preview.ts
+++ b/src/commands/agent/preview.ts
@@ -101,7 +101,7 @@ export default class AgentPreview extends SfCommand<AgentPreviewResult> {
       });
     }
 
-    const outputDir = await resolveOutputDir(flags['output-dir']);
+    const outputDir = await resolveOutputDir(flags['output-dir'], flags['apex-debug']);
     const agentPreview = new Preview(apiConn, selectedAgent.Id);
     agentPreview.toggleApexDebugMode(flags['apex-debug']);
 
@@ -156,16 +156,22 @@ export const getAgentChoices = (agents: AgentData[]): Array<Choice<AgentValue>> 
     };
   });
 
-export const resolveOutputDir = async (outputDir: string | undefined): Promise<string | undefined> => {
+export const resolveOutputDir = async (
+  outputDir: string | undefined,
+  apexDebug: boolean | undefined
+): Promise<string | undefined> => {
   if (!outputDir) {
-    const response = await confirm({
-      message: 'Save transcripts to an output directory?',
-      default: true,
-    });
+    const response = apexDebug
+      ? true
+      : await confirm({
+          message: 'Save transcripts to an output directory?',
+          default: true,
+        });
 
+    const outputTypes = apexDebug ? 'debug logs and transcripts' : 'transcripts';
     if (response) {
       const getDir = await input({
-        message: 'Enter the output directory',
+        message: `Enter the output directory for ${outputTypes}`,
         default: env.getString('SF_AGENT_PREVIEW_OUTPUT_DIR', join('temp', 'agent-preview')),
         required: true,
       });

--- a/src/commands/agent/preview.ts
+++ b/src/commands/agent/preview.ts
@@ -67,6 +67,10 @@ export default class AgentPreview extends SfCommand<AgentPreviewResult> {
       summary: messages.getMessage('flags.output-dir.summary'),
       char: 'd',
     }),
+    'apex-debug': Flags.boolean({
+      summary: messages.getMessage('flags.apex-debug.summary'),
+      char: 'x',
+    }),
   };
 
   public async run(): Promise<AgentPreviewResult> {
@@ -98,12 +102,13 @@ export default class AgentPreview extends SfCommand<AgentPreviewResult> {
     }
 
     const outputDir = await resolveOutputDir(flags['output-dir']);
-    const agentPreview = new Preview(apiConn);
+    const agentPreview = new Preview(apiConn, selectedAgent.Id);
+    agentPreview.toggleApexDebugMode(flags['apex-debug']);
 
     const instance = render(
       React.createElement(AgentPreviewReact, {
+        connection: conn,
         agent: agentPreview,
-        id: selectedAgent.Id,
         name: selectedAgent.DeveloperName,
         outputDir,
       }),

--- a/src/components/agent-preview-react.tsx
+++ b/src/components/agent-preview-react.tsx
@@ -81,6 +81,7 @@ export function AgentPreviewReact(props: {
   const [timestamp, setTimestamp] = React.useState(new Date().getTime());
   const [tempDir, setTempDir] = React.useState('');
   const [responses, setResponses] = React.useState<AgentPreviewSendResponse[]>([]);
+  const [apexDebugLogs, setApexDebugLogs] = React.useState<string[]>([]);
 
   const { connection, agent, name, outputDir } = props;
 
@@ -213,8 +214,12 @@ export function AgentPreviewReact(props: {
 
             // If there is an apex debug log entry, get the log and write it to the output dir
             if (response.apexDebugLog && tempDir) {
-              // Write the apex debug  to the output dir
+              // Write the apex debug to the output dir
               await writeDebugLog(connection, response.apexDebugLog, tempDir);
+              const logId = response.apexDebugLog.Id;
+              if (logId) {
+                setApexDebugLogs((prev) => [...prev, path.join(tempDir, `${logId}.log`)]);
+              }
             }
           }}
         />
@@ -233,6 +238,7 @@ export function AgentPreviewReact(props: {
           <Text bold>Session Ended</Text>
           {outputDir ? <Text>Conversation log: {tempDir}/transcript.json</Text> : null}
           {outputDir ? <Text>API transactions: {tempDir}/responses.json</Text> : null}
+          {apexDebugLogs.length > 0 && <Text>Apex Debug Logs: {'\n' + apexDebugLogs.join('\n')}</Text>}
         </Box>
       ) : null}
     </Box>

--- a/src/components/agent-preview-react.tsx
+++ b/src/components/agent-preview-react.tsx
@@ -10,7 +10,8 @@ import fs from 'node:fs';
 import React from 'react';
 import { Box, Text, useInput } from 'ink';
 import TextInput from 'ink-text-input';
-import { AgentPreview, AgentPreviewSendResponse } from '@salesforce/agents';
+import { Connection } from '@salesforce/core';
+import { AgentPreview, AgentPreviewSendResponse, writeDebugLog } from '@salesforce/agents';
 import { sleep } from '@salesforce/kit';
 
 // Component to show a simple typing animation
@@ -64,8 +65,8 @@ const saveTranscriptsToFile = (
  * - Add keystroke to scroll down
  */
 export function AgentPreviewReact(props: {
+  readonly connection: Connection;
   readonly agent: AgentPreview;
-  readonly id: string;
   readonly name: string;
   readonly outputDir: string | undefined;
 }): React.ReactNode {
@@ -81,7 +82,7 @@ export function AgentPreviewReact(props: {
   const [tempDir, setTempDir] = React.useState('');
   const [responses, setResponses] = React.useState<AgentPreviewSendResponse[]>([]);
 
-  const { agent, id, name, outputDir } = props;
+  const { connection, agent, name, outputDir } = props;
 
   useInput((input, key) => {
     if (key.escape) {
@@ -105,7 +106,7 @@ export function AgentPreviewReact(props: {
 
   React.useEffect(() => {
     const startSession = async (): Promise<void> => {
-      const session = await agent.start(id);
+      const session = await agent.start();
       setSessionId(session.sessionId);
       setHeader(`New session started with "${props.name}" (${session.sessionId})`);
       await sleep(500); // Add a short delay to make it feel more natural
@@ -209,6 +210,12 @@ export function AgentPreviewReact(props: {
 
             // Add the agent's response to the chat
             setMessages((prev) => [...prev, { role: name, content: message, timestamp: new Date() }]);
+
+            // If there is an apex debug log entry, get the log and write it to the output dir
+            if (response.apexDebugLog && tempDir) {
+              // Write the apex debug  to the output dir
+              await writeDebugLog(connection, response.apexDebugLog, tempDir);
+            }
           }}
         />
       </Box>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1443,10 +1443,10 @@
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
-"@salesforce/agents@0.14.14-dev.0":
-  version "0.14.14-dev.0"
-  resolved "https://registry.yarnpkg.com/@salesforce/agents/-/agents-0.14.14-dev.0.tgz#e2a785e40b11d275619a5d1109e240da353da2e3"
-  integrity sha512-5P1Bqopibrx2lp8hJvFMMVOwNfwGHyIT/lrnUUBKa6en8XUJX43Sys+5+jj8la7gYoSq75PSwz4v98BDhiVbHA==
+"@salesforce/agents@0.15.0":
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/agents/-/agents-0.15.0.tgz#0cec640cef0f02714bfa8cf842239c9d00e6ca15"
+  integrity sha512-chshRBql+Yxm68vl2vI3BlmJdIBvyxVcj9WqlXQ51XwtzIsC64JSXZ1maybf05tdLQQiq+y8Z+b9/Vn6bfzvyw==
   dependencies:
     "@salesforce/core" "^8.10.3"
     "@salesforce/kit" "^3.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1443,14 +1443,15 @@
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
-"@salesforce/agents@0.14.11":
-  version "0.14.11"
-  resolved "https://registry.yarnpkg.com/@salesforce/agents/-/agents-0.14.11.tgz#3623d5d9708b9be12e72257592c1cc954a0a4d64"
-  integrity sha512-pRswx4MY7NfGAvPhKh6HDgGcvorcMJVjOaD2CHYLynVAhnvSioBv81BAc236sJoMpnOC68x/+DN312dlm3w9pw==
+"@salesforce/agents@0.14.14-dev.0":
+  version "0.14.14-dev.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/agents/-/agents-0.14.14-dev.0.tgz#e2a785e40b11d275619a5d1109e240da353da2e3"
+  integrity sha512-5P1Bqopibrx2lp8hJvFMMVOwNfwGHyIT/lrnUUBKa6en8XUJX43Sys+5+jj8la7gYoSq75PSwz4v98BDhiVbHA==
   dependencies:
-    "@salesforce/core" "^8.10.2"
+    "@salesforce/core" "^8.10.3"
     "@salesforce/kit" "^3.2.3"
-    "@salesforce/source-deploy-retrieve" "^12.19.3"
+    "@salesforce/source-deploy-retrieve" "^12.19.5"
+    "@salesforce/types" "^1.3.0"
     fast-xml-parser "^4.5.3"
     nock "^13.5.6"
     yaml "^2.7.1"
@@ -1471,10 +1472,10 @@
     strip-ansi "6.0.1"
     ts-retry-promise "^0.8.1"
 
-"@salesforce/core@^8.10.0", "@salesforce/core@^8.10.2", "@salesforce/core@^8.5.1", "@salesforce/core@^8.8.0", "@salesforce/core@^8.8.5", "@salesforce/core@^8.8.7":
-  version "8.10.2"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.10.2.tgz#22727a7dee2e69a34b0b14dae39c025f2b258af0"
-  integrity sha512-o/Qvm0U9+nuHAdFfjXZoAXyLaeG7lDnrLmUkCQ38oquiFrwzWSbXh6crHqFEmeZyK6MYYgh0KCaInrui06XP6Q==
+"@salesforce/core@^8.10.0", "@salesforce/core@^8.10.2", "@salesforce/core@^8.10.3", "@salesforce/core@^8.5.1", "@salesforce/core@^8.8.0", "@salesforce/core@^8.8.5":
+  version "8.10.3"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-8.10.3.tgz#3cc2c99d097757cb4b08dab921254cfa3a00c7c1"
+  integrity sha512-juqbU304TBrrjb8sZGw+QkeAJISKu4+v2XIMTCxGJoEjs4LLhsyI7/drxCUY+7FNye+veAGeJdn/PCxkKhSgcA==
   dependencies:
     "@jsforce/jsforce-node" "^3.8.1"
     "@salesforce/kit" "^3.2.2"
@@ -1597,12 +1598,12 @@
     cli-progress "^3.12.0"
     terminal-link "^3.0.0"
 
-"@salesforce/source-deploy-retrieve@^12.19.3":
-  version "12.19.3"
-  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-12.19.3.tgz#42b34913b624115aee36cd289cb5ea1d5de9b7b1"
-  integrity sha512-rvdEfi2beJmVbN4NQ3Ve4dULq+wMFuLKBKpmNBIb9udXNVZd8Q0P7TO9pM/tzfeAfwfdTE7swXaYe2Qv5UAd+g==
+"@salesforce/source-deploy-retrieve@^12.19.3", "@salesforce/source-deploy-retrieve@^12.19.5":
+  version "12.19.6"
+  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-12.19.6.tgz#0c208d2dfef6944e24afcea74ed05aa823e966aa"
+  integrity sha512-A/886Ht23G1snfyUj26pNDjaRWuMmiWIk5ckp+d9mdQjV8i45kPiOFJj5aHzAQ8071i/JgfnDYEhnk1voDujUA==
   dependencies:
-    "@salesforce/core" "^8.8.7"
+    "@salesforce/core" "^8.10.3"
     "@salesforce/kit" "^3.2.3"
     "@salesforce/ts-types" "^2.0.12"
     "@salesforce/types" "^1.3.0"


### PR DESCRIPTION
### What does this PR do?
Adds a new flag to the `agent preview` command to enable apex debug logs during agent conversation preview. When this flag is enabled, during each agent message send/retrieve that executes apex code there will be an apex debug log file written to the provided output directory.

### What issues does this PR fix or reference?
@W-18417013@