### PR TITLE
W-18506859: exclude node_modules dir from yaml files inspection

### DIFF
--- a/src/flags.ts
+++ b/src/flags.ts
@@ -77,16 +77,16 @@ export function makeFlags<T extends Record<string, FlaggablePrompt>>(flaggablePr
   ) as FlagsOfPrompts<T>;
 }
 
-async function traverseForFiles(dir: string, suffixes: string[]): Promise<string[]> {
+export async function traverseForFiles(dir: string, suffixes: string[], excludeDirs?: string[]): Promise<string[]> {
   const files = await readdir(dir, { withFileTypes: true });
   const results: string[] = [];
 
   for (const file of files) {
     const fullPath = join(dir, file.name);
 
-    if (file.isDirectory()) {
+    if (file.isDirectory() && !excludeDirs?.includes(file.name)) {
       // eslint-disable-next-line no-await-in-loop
-      results.push(...(await traverseForFiles(fullPath, suffixes)));
+      results.push(...(await traverseForFiles(fullPath, suffixes, excludeDirs)));
     } else if (suffixes.some((suffix) => file.name.endsWith(suffix))) {
       results.push(fullPath);
     }
@@ -127,7 +127,7 @@ export const promptForAiEvaluationDefinitionApiName = async (
 };
 
 export const promptForYamlFile = async (flagDef: FlaggablePrompt): Promise<string> => {
-  const yamlFiles = await traverseForFiles(process.cwd(), ['.yml', '.yaml']);
+  const yamlFiles = await traverseForFiles(process.cwd(), ['.yml', '.yaml'], ['node_modules']);
   return autocomplete({
     message: flagDef.message,
     // eslint-disable-next-line @typescript-eslint/require-await

--- a/test/flags.test.ts
+++ b/test/flags.test.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { join } from 'node:path';
+import { mkdir, writeFile, rm } from 'node:fs/promises';
+import { expect } from 'chai';
+import { traverseForFiles } from '../src/flags.js';
+
+describe('traverseForFiles', () => {
+  const testDir = join(process.cwd(), 'test-temp');
+  const testFiles = [
+    'file1.yml',
+    'file2.yaml',
+    'subdir/file3.yml',
+    'subdir/file4.yaml',
+    'node_modules/file5.yml',
+    'excluded/file6.yaml',
+  ] as const;
+
+  before(async () => {
+    // Create directory structure and test files
+    await mkdir(testDir, { recursive: true });
+    await mkdir(join(testDir, 'subdir'), { recursive: true });
+    await mkdir(join(testDir, 'node_modules'), { recursive: true });
+    await mkdir(join(testDir, 'excluded'), { recursive: true });
+
+    // Create test files
+    await Promise.all(testFiles.map((file) => writeFile(join(testDir, file), 'test content')));
+  });
+
+  after(async () => {
+    // Clean up test files
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it('should find all yaml files when no excludeDirs is provided', async () => {
+    const results = await traverseForFiles(testDir, ['.yml', '.yaml']);
+    expect(results).to.have.lengthOf(6);
+    expect(results).to.include(join(testDir, 'file1.yml'));
+    expect(results).to.include(join(testDir, 'file2.yaml'));
+    expect(results).to.include(join(testDir, 'subdir/file3.yml'));
+    expect(results).to.include(join(testDir, 'subdir/file4.yaml'));
+    expect(results).to.include(join(testDir, 'node_modules/file5.yml'));
+    expect(results).to.include(join(testDir, 'excluded/file6.yaml'));
+  });
+
+  it('should exclude specified directories', async () => {
+    const results = await traverseForFiles(testDir, ['.yml', '.yaml'], ['node_modules', 'excluded']);
+    expect(results).to.have.lengthOf(4);
+    expect(results).to.include(join(testDir, 'file1.yml'));
+    expect(results).to.include(join(testDir, 'file2.yaml'));
+    expect(results).to.include(join(testDir, 'subdir/file3.yml'));
+    expect(results).to.include(join(testDir, 'subdir/file4.yaml'));
+    expect(results).to.not.include(join(testDir, 'node_modules/file5.yml'));
+    expect(results).to.not.include(join(testDir, 'excluded/file6.yaml'));
+  });
+
+  it('should handle empty excludeDirs array', async () => {
+    const results = await traverseForFiles(testDir, ['.yml', '.yaml'], []);
+    expect(results).to.have.lengthOf(6);
+  });
+});

--- a/test/flags.test.ts
+++ b/test/flags.test.ts
@@ -15,10 +15,10 @@ describe('traverseForFiles', () => {
   const testFiles = [
     'file1.yml',
     'file2.yaml',
-    'subdir/file3.yml',
-    'subdir/file4.yaml',
-    'node_modules/file5.yml',
-    'excluded/file6.yaml',
+    join('subdir', 'file3.yml'),
+    join('subdir', 'file4.yaml'),
+    join('node_modules', 'file5.yml'),
+    join('excluded', 'file6.yaml'),
   ] as const;
 
   before(async () => {
@@ -42,10 +42,10 @@ describe('traverseForFiles', () => {
     expect(results).to.have.lengthOf(6);
     expect(results).to.include(join(testDir, 'file1.yml'));
     expect(results).to.include(join(testDir, 'file2.yaml'));
-    expect(results).to.include(join(testDir, 'subdir/file3.yml'));
-    expect(results).to.include(join(testDir, 'subdir/file4.yaml'));
-    expect(results).to.include(join(testDir, 'node_modules/file5.yml'));
-    expect(results).to.include(join(testDir, 'excluded/file6.yaml'));
+    expect(results).to.include(join(testDir, 'subdir', 'file3.yml'));
+    expect(results).to.include(join(testDir, 'subdir', 'file4.yaml'));
+    expect(results).to.include(join(testDir, 'node_modules', 'file5.yml'));
+    expect(results).to.include(join(testDir, 'excluded', 'file6.yaml'));
   });
 
   it('should exclude specified directories', async () => {
@@ -53,10 +53,10 @@ describe('traverseForFiles', () => {
     expect(results).to.have.lengthOf(4);
     expect(results).to.include(join(testDir, 'file1.yml'));
     expect(results).to.include(join(testDir, 'file2.yaml'));
-    expect(results).to.include(join(testDir, 'subdir/file3.yml'));
-    expect(results).to.include(join(testDir, 'subdir/file4.yaml'));
-    expect(results).to.not.include(join(testDir, 'node_modules/file5.yml'));
-    expect(results).to.not.include(join(testDir, 'excluded/file6.yaml'));
+    expect(results).to.include(join(testDir, 'subdir', 'file3.yml'));
+    expect(results).to.include(join(testDir, 'subdir', 'file4.yaml'));
+    expect(results).to.not.include(join(testDir, 'node_modules', 'file5.yml'));
+    expect(results).to.not.include(join(testDir, 'excluded', 'file6.yaml'));
   });
 
   it('should handle empty excludeDirs array', async () => {


### PR DESCRIPTION
### What does this PR do?
Excludes YAML files from`node_modules` directory as suggestions for file specs.
### What issues does this PR fix or reference?
[@W-18506859@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002ELrgUYAT/view)