### PR TITLE
fix: clarify timing of save prompt for agent preview in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ DESCRIPTION
   the agent uses a particular topic when asked a question, and then whether it invokes the correct action associated
   with that topic. This command is the CLI-equivalent of the Conversation Preview panel in your org's Agent Builder UI.
 
-  When the session concludes, the command asks if you want to save the API responses and chat transcripts. By default,
+  Before the session starts, the command asks if you want to save the API responses and chat transcripts. By default,
   the files are saved to the "./temp/agent-preview" directory. Specify a new default directory by setting the
   environment variable "SF_AGENT_PREVIEW_OUTPUT_DIR" to the directory. Or you can pass the directory to the --output-dir
   flag.


### PR DESCRIPTION
### What does this PR do?

Correct the README explaining when the commands ask to save the API responses and chat transcripts
In v1.22.1, the user needs to answer questions about saving before talking to the agent:

<img width="1156" alt="image" src="https://github.com/user-attachments/assets/c7e0607c-313e-4195-930e-23db4370a4b3" />


### What issues does this PR fix or reference?

The issues are disabled on the repo, I couldn't create one:
<img width="836" alt="image" src="https://github.com/user-attachments/assets/9438397d-7b66-4d2c-9b00-bb4b7290ee2f" />


Please tell me if I need to do something else.