### PR TITLE
W-18551233: use correct flag name in success  message

### DIFF
--- a/src/commands/agent/create.ts
+++ b/src/commands/agent/create.ts
@@ -206,7 +206,7 @@ export default class AgentCreate extends SfCommand<AgentCreateResult> {
         this.log(
           `Use ${colorize(
             'dim',
-            `sf org open agent --name ${agentApiName} -o ${orgUsername}`
+            `sf org open agent --api-name ${agentApiName} -o ${orgUsername}`
           )} to view the agent in the browser.`
         );
       } else {


### PR DESCRIPTION
### What does this PR do?
Use correct flag name in success message's suggestion.

### What issues does this PR fix or reference?
[@W-18551233@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002Ecx62YAB/view)