### PR TITLE
chore: add --authoring-bundle and SF_DEMO_AGENT_ID env var for DF Demo @W-19619766@

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -72,7 +72,16 @@
     "command": "agent:preview",
     "flagAliases": [],
     "flagChars": ["c", "d", "n", "o", "x"],
-    "flags": ["apex-debug", "api-name", "api-version", "client-app", "flags-dir", "output-dir", "target-org"],
+    "flags": [
+      "apex-debug",
+      "api-name",
+      "api-version",
+      "authoring-bundle",
+      "client-app",
+      "flags-dir",
+      "output-dir",
+      "target-org"
+    ],
     "plugin": "@salesforce/plugin-agent"
   },
   {

--- a/messages/agent.preview.md
+++ b/messages/agent.preview.md
@@ -18,6 +18,10 @@ IMPORTANT: Before you use this command, you must complete a number of configurat
 
 API name of the agent you want to interact with.
 
+# flags.authoring-bundle.summary
+
+Preview an ephemeral afscript agent by specifying the API name of the Authoring Bundle metadata
+
 # flags.client-app.summary
 
 Name of the linked client app to use for the agent connection. You must have previously created this link with "org login web --client-app". Run "org display" to see the available linked client apps.

--- a/src/commands/agent/preview.ts
+++ b/src/commands/agent/preview.ts
@@ -15,6 +15,7 @@
  */
 
 import { resolve, join } from 'node:path';
+import * as process from 'node:process';
 import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
 import { AuthInfo, Connection, Messages, SfError } from '@salesforce/core';
 import React from 'react';
@@ -73,6 +74,9 @@ export default class AgentPreview extends SfCommand<AgentPreviewResult> {
       summary: messages.getMessage('flags.api-name.summary'),
       char: 'n',
     }),
+    'authoring-bundle': Flags.string({
+      summary: messages.getMessage('flags.authoring-bundle.summary'),
+    }),
     'output-dir': Flags.directory({
       summary: messages.getMessage('flags.output-dir.summary'),
       char: 'd',
@@ -108,7 +112,12 @@ export default class AgentPreview extends SfCommand<AgentPreviewResult> {
 
     let selectedAgent;
 
-    if (apiNameFlag) {
+    if (flags['authoring-bundle']) {
+      selectedAgent = {
+        Id: process.env.SF_DEMO_AGENT_ID ?? 'SF_DEMO_AGENT_ID is unset',
+        DeveloperName: flags['authoring-bundle'],
+      };
+    } else if (apiNameFlag) {
       selectedAgent = agentsInOrg.find((agent) => agent.DeveloperName === apiNameFlag);
       if (!selectedAgent) throw new Error(`No valid Agents were found with the Api Name ${apiNameFlag}.`);
       validateAgent(selectedAgent);


### PR DESCRIPTION
### What does this PR do?
updates `agent preview` to have an `--authoring-bundle` that is a noop flag, and only accepts the name as the Developer Name, there's also a required env var, `SF_DEMO_AGENT_ID` which is the ID of the agent that will actually be previewed


### What issues does this PR fix or reference?
@W-19619766@

```bash
 ➜  SF_DEMO_AGENT_ID=0Xxed00000002HxCAI ../../oss/plugin-agent/bin/run.js agent preview --authoring-bundle Guest_Experience_Agent --client-app agent-app
Warning: This command is currently in beta. Any aspect of this command can change without advanced notice. Don't use beta commands in your scripts.
✔ Save transcripts to an output directory? No

╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                             Starting session...                                                                                              │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

Guest_Experience_Agent 9/22/2025, 2:47:46 PM
╭─────╮
│ ... │
╰─────╯

```