### PR TITLE
chore: longer timeout

### DIFF
--- a/test/nuts/agent.nut.ts
+++ b/test/nuts/agent.nut.ts
@@ -184,8 +184,10 @@ describe('plugin-agent NUTs', () => {
         execCmd(`agent activate --api-name ${botApiName} --target-org ${username} --json`, { ensureExitCode: 0 });
       } catch (err) {
         const errMsg = err instanceof Error ? err.message : 'unknown';
-        console.log(`Error activating agent due to ${errMsg}. \nWaiting 2 minutes and trying again...`);
-        await sleep(120_000);
+        const waitMin = 3;
+        console.log(`Error activating agent due to ${errMsg}. \nWaiting ${waitMin} minutes and trying again...`);
+        await sleep(waitMin * 60 * 1000);
+        console.log(`${waitMin} minutes is up, retrying now.`);
         execCmd(`agent activate --api-name ${botApiName} --target-org ${username} --json`, { ensureExitCode: 0 });
       }
 


### PR DESCRIPTION
### What does this PR do?
Increases the timeout for agent provisioning before trying to activate/deactivate 

Trying to fix this flakey test https://github.com/salesforcecli/cli/actions/runs/18116967553/job/51554877152

### What issues does this PR fix or reference?
[skip-validate-pr]
