### PR TITLE
W-19795168: remove --client-app flag req and SF_DEMO_AGENT_CLIENT_APP env var for DF Demo

### DIFF
--- a/src/commands/agent/preview.ts
+++ b/src/commands/agent/preview.ts
@@ -131,8 +131,6 @@ export default class AgentPreview extends SfCommand<AgentPreviewResult> {
       });
     }
 
-    // eslint-disable-next-line no-console
-    console.log('clientApp', clientApp);
     const jwtConn = await Connection.create({
       authInfo,
       clientApp,


### PR DESCRIPTION
### What does this PR do?
Updates `agent preview` to have` --client-app` flag as not required, and adds a required env var, SF_DEMO_AGENT_CLIENT_APP which is the name of the connected app the agent is connected to.

### What issues does this PR fix or reference?
[@W-19795168@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002MgnYWYAZ/view)