### PR TITLE
fix: add --api-name flag to generate authoring-bundle command

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -56,7 +56,7 @@
     "command": "agent:generate:authoring-bundle",
     "flagAliases": [],
     "flagChars": ["d", "f", "n", "o"],
-    "flags": ["api-version", "flags-dir", "json", "name", "output-dir", "spec", "target-org"],
+    "flags": ["api-name", "api-version", "flags-dir", "json", "name", "output-dir", "spec", "target-org"],
     "plugin": "@salesforce/plugin-agent"
   },
   {

--- a/messages/agent.generate.authoring-bundle.md
+++ b/messages/agent.generate.authoring-bundle.md
@@ -16,11 +16,15 @@ Directory where the authoring bundle files will be generated.
 
 # flags.name.summary
 
-Name (label) of the authoring bundle. If not provided, you will be prompted for it.
+Name (label) of the authoring bundle.
 
-# flags.name.prompt
+# flags.api-name.summary
 
-Name (label) of the authoring bundle
+API name of the new authoring bundle; if not specified, the API name is derived from the authoring bundle name (label); the API name must not exist in the org.
+
+# flags.api-name.prompt
+
+API name of the new authoring bundle
 
 # examples
 

--- a/src/commands/agent/generate/authoring-bundle.ts
+++ b/src/commands/agent/generate/authoring-bundle.ts
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 
-import { join } from 'node:path';
-import { mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { mkdirSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
 import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
-import { Messages, SfError } from '@salesforce/core';
+import { generateApiName, Messages, SfError } from '@salesforce/core';
 import { Agent, AgentJobSpec } from '@salesforce/agents';
 import YAML from 'yaml';
-import { FlaggablePrompt, promptForFlag } from '../../../flags.js';
+import { input as inquirerInput } from '@inquirer/prompts';
+import { theme } from '../../../inquirer-theme.js';
+import { FlaggablePrompt, promptForFlag, promptForYamlFile } from '../../../flags.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-agent', 'agent.generate.authoring-bundle');
@@ -39,6 +41,9 @@ export default class AgentGenerateAuthoringBundle extends SfCommand<AgentGenerat
 
   public static readonly flags = {
     'target-org': Flags.requiredOrg(),
+    'api-name': Flags.string({
+      summary: messages.getMessage('flags.api-name.summary'),
+    }),
     'api-version': Flags.orgApiVersion(),
     spec: Flags.file({
       summary: messages.getMessage('flags.spec.summary'),
@@ -58,13 +63,35 @@ export default class AgentGenerateAuthoringBundle extends SfCommand<AgentGenerat
   private static readonly FLAGGABLE_PROMPTS = {
     name: {
       message: messages.getMessage('flags.name.summary'),
-      promptMessage: messages.getMessage('flags.name.prompt'),
       validate: (d: string): boolean | string => d.length > 0 || 'Name cannot be empty',
       required: true,
     },
+    'api-name': {
+      message: messages.getMessage('flags.api-name.summary'),
+      promptMessage: messages.getMessage('flags.api-name.prompt'),
+      validate: (d: string): boolean | string => {
+        if (d.length === 0) {
+          return true;
+        }
+        if (d.length > 80) {
+          return 'API name cannot be over 80 characters.';
+        }
+        const regex = /^[A-Za-z][A-Za-z0-9_]*[A-Za-z0-9]+$/;
+        if (!regex.test(d)) {
+          return 'Invalid API name.';
+        }
+        return true;
+      },
+    },
     spec: {
       message: messages.getMessage('flags.spec.summary'),
-      validate: (d: string): boolean | string => d.length > 0 || 'Spec file path cannot be empty',
+      validate: (d: string): boolean | string => {
+        const specPath = resolve(d);
+        if (!existsSync(specPath)) {
+          return 'Please enter an existing agent spec (yaml) file';
+        }
+        return true;
+      },
       required: true,
     },
   } satisfies Record<string, FlaggablePrompt>;
@@ -74,12 +101,25 @@ export default class AgentGenerateAuthoringBundle extends SfCommand<AgentGenerat
     const { 'output-dir': outputDir, 'target-org': targetOrg } = flags;
 
     // If we don't have a spec yet, prompt for it
-    const spec = flags['spec'] ?? (await promptForFlag(AgentGenerateAuthoringBundle.FLAGGABLE_PROMPTS['spec']));
+    const spec = flags.spec ?? (await promptForYamlFile(AgentGenerateAuthoringBundle.FLAGGABLE_PROMPTS['spec']));
 
     // If we don't have a name yet, prompt for it
-    const name = (
-      flags['name'] ?? (await promptForFlag(AgentGenerateAuthoringBundle.FLAGGABLE_PROMPTS['name']))
-    ).replaceAll(' ', '_');
+    const name = flags['name'] ?? (await promptForFlag(AgentGenerateAuthoringBundle.FLAGGABLE_PROMPTS['name']));
+
+    // If we don't have an api name yet, prompt for it
+    let bundleApiName = flags['api-name'];
+    if (!bundleApiName) {
+      bundleApiName = generateApiName(name);
+      const promptedValue = await inquirerInput({
+        message: messages.getMessage('flags.api-name.prompt'),
+        validate: AgentGenerateAuthoringBundle.FLAGGABLE_PROMPTS['api-name'].validate,
+        default: bundleApiName,
+        theme,
+      });
+      if (promptedValue?.length) {
+        bundleApiName = promptedValue;
+      }
+    }
 
     try {
       // Get default output directory if not specified

--- a/test/nuts/agent.generate.authoring-bundle.nut.ts
+++ b/test/nuts/agent.generate.authoring-bundle.nut.ts
@@ -56,7 +56,7 @@ describe.skip('agent generate authoring-bundle NUTs', () => {
       execCmd(specCommand, { ensureExitCode: 0 });
 
       // Now generate the authoring bundle
-      const command = `agent generate authoring-bundle --spec ${specPath} --name ${bundleName} --target-org ${username} --json`;
+      const command = `agent generate authoring-bundle --spec ${specPath} --name ${bundleName} --api-name ${bundleName} --target-org ${username} --json`;
       const result = execCmd<AgentGenerateAuthoringBundleResult>(command, { ensureExitCode: 0 }).jsonOutput?.result;
 
       expect(result).to.be.ok;


### PR DESCRIPTION
### What does this PR do?
Adds new --api-name flag to `agent generate authoring-bundle` command. This flag is prompt-able and there is logic to generate an api name based on name when the flag is not used.

Also adds logic around spec flag so when it's not used, the user will be ask to select a yaml file from a list of files in the project.

### What issues does this PR fix or reference?
[@W-19802416@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002MkIz2YAF/view)