### PR TITLE
chore: fix git2gus product tag @W-21858920@

### DIFF
--- a/.git2gus/config.json
+++ b/.git2gus/config.json
@@ -1,5 +1,5 @@
 {
-  "productTag": "a1aB00000004Bx8IAE",
+  "productTag": "a1aEE000001vDZRYA2",
   "defaultBuild": "offcore.tooling.56",
   "issueTypeLabels": {
     "feature": "USER STORY",


### PR DESCRIPTION
### What does this PR do?
updates the product tag for git12gus to `agentforce DX`
### What issues does this PR fix or reference?
@W-21858920@