### PR TITLE
@W-22203665 feat: add agentApiName to agent preview start and send JSON output

### DIFF
--- a/schemas/agent-preview-send.json
+++ b/schemas/agent-preview-send.json
@@ -19,9 +19,15 @@
             },
             "additionalProperties": false
           }
+        },
+        "agentApiName": {
+          "type": "string"
+        },
+        "sessionId": {
+          "type": "string"
         }
       },
-      "required": ["messages"],
+      "required": ["messages", "agentApiName", "sessionId"],
       "additionalProperties": false
     }
   }

--- a/schemas/agent-preview-start.json
+++ b/schemas/agent-preview-start.json
@@ -7,9 +7,12 @@
       "properties": {
         "sessionId": {
           "type": "string"
+        },
+        "agentApiName": {
+          "type": "string"
         }
       },
-      "required": ["sessionId"],
+      "required": ["sessionId", "agentApiName"],
       "additionalProperties": false
     }
   }

--- a/src/commands/agent/preview/send.ts
+++ b/src/commands/agent/preview/send.ts
@@ -24,6 +24,8 @@ const messages = Messages.loadMessages('@salesforce/plugin-agent', 'agent.previe
 
 export type AgentPreviewSendResult = {
   messages: Array<{ message?: string; role?: string }>;
+  agentApiName: string;
+  sessionId: string;
 };
 
 export default class AgentPreviewSend extends SfCommand<AgentPreviewSendResult> {
@@ -139,6 +141,6 @@ export default class AgentPreviewSend extends SfCommand<AgentPreviewSendResult> 
 
     await Lifecycle.getInstance().emitTelemetry({ eventName: 'agent_preview_send_success' });
     this.log(response.messages[0].message);
-    return { messages: response.messages ?? [] };
+    return { messages: response.messages ?? [], agentApiName: agentIdentifier, sessionId };
   }
 }

--- a/src/commands/agent/preview/start.ts
+++ b/src/commands/agent/preview/start.ts
@@ -25,6 +25,7 @@ const messages = Messages.loadMessages('@salesforce/plugin-agent', 'agent.previe
 
 export type AgentPreviewStartResult = {
   sessionId: string;
+  agentApiName: string;
 };
 
 export default class AgentPreviewStart extends SfCommand<AgentPreviewStartResult> {
@@ -160,7 +161,7 @@ export default class AgentPreviewStart extends SfCommand<AgentPreviewStartResult
     await createCache(agent, { displayName });
 
     await Lifecycle.getInstance().emitTelemetry({ eventName: 'agent_preview_start_success' });
-    const result: AgentPreviewStartResult = { sessionId: session.sessionId };
+    const result: AgentPreviewStartResult = { sessionId: session.sessionId, agentApiName: agentIdentifier };
     this.log(messages.getMessage('output.sessionId', [session.sessionId]));
     return result;
   }

--- a/test/nuts/z3.agent.preview.nut.ts
+++ b/test/nuts/z3.agent.preview.nut.ts
@@ -61,17 +61,22 @@ describe('agent preview', function () {
         `agent preview start --authoring-bundle ${bundleApiName} --simulate-actions --target-org ${targetOrg} --json`
       ).jsonOutput?.result;
       expect(startResult?.sessionId).to.be.a('string');
+      expect(startResult?.agentApiName).to.equal(bundleApiName);
       const sessionId = startResult!.sessionId;
 
       const sendResult1 = execCmd<AgentPreviewSendResult>(
         `agent preview send --session-id ${sessionId} --authoring-bundle ${bundleApiName} --utterance "What can you help me with?" --target-org ${targetOrg} --json`
       ).jsonOutput?.result;
       expect(sendResult1?.messages).to.be.an('array').with.length.greaterThan(0);
+      expect(sendResult1?.agentApiName).to.equal(bundleApiName);
+      expect(sendResult1?.sessionId).to.equal(sessionId);
 
       const sendResult2 = execCmd<AgentPreviewSendResult>(
         `agent preview send --session-id ${sessionId} --authoring-bundle ${bundleApiName} --utterance "Tell me more" --target-org ${targetOrg} --json`
       ).jsonOutput?.result;
       expect(sendResult2?.messages).to.be.an('array').with.length.greaterThan(0);
+      expect(sendResult2?.agentApiName).to.equal(bundleApiName);
+      expect(sendResult2?.sessionId).to.equal(sessionId);
 
       const endResult = execCmd<AgentPreviewEndResult>(
         `agent preview end --session-id ${sessionId} --authoring-bundle ${bundleApiName} --target-org ${targetOrg} --json`
@@ -95,12 +100,15 @@ describe('agent preview', function () {
         `agent preview start --authoring-bundle ${publishedAgent?.DeveloperName} --use-live-actions --target-org ${targetOrg} --json`
       ).jsonOutput?.result;
       expect(startResult?.sessionId).to.be.a('string');
+      expect(startResult?.agentApiName).to.equal(publishedAgent?.DeveloperName);
       const sessionId = startResult!.sessionId;
 
       const sendResult1 = execCmd<AgentPreviewSendResult>(
         `agent preview send --session-id ${sessionId} --authoring-bundle ${publishedAgent?.DeveloperName} --utterance "What can you help me with?" --target-org ${targetOrg} --json`
       ).jsonOutput?.result;
       expect(sendResult1?.messages).to.be.an('array').with.length.greaterThan(0);
+      expect(sendResult1?.agentApiName).to.equal(publishedAgent?.DeveloperName);
+      expect(sendResult1?.sessionId).to.equal(sessionId);
 
       execCmd<AgentPreviewEndResult>(
         `agent preview end --session-id ${sessionId} --authoring-bundle ${publishedAgent?.DeveloperName} --target-org ${targetOrg} --json`
@@ -130,6 +138,7 @@ describe('agent preview', function () {
         `agent preview start --api-name ${publishedAgent!.DeveloperName} --target-org ${targetOrg} --json`
       ).jsonOutput?.result;
       expect(startResult?.sessionId).to.be.a('string');
+      expect(startResult?.agentApiName).to.equal(publishedAgent!.DeveloperName);
       const sessionId = startResult!.sessionId;
 
       const sendResult = execCmd<AgentPreviewSendResult>(
@@ -138,6 +147,8 @@ describe('agent preview', function () {
         } --utterance "What can you help me with?" --target-org ${targetOrg} --json`
       ).jsonOutput?.result;
       expect(sendResult?.messages).to.be.an('array').with.length.greaterThan(0);
+      expect(sendResult?.agentApiName).to.equal(publishedAgent!.DeveloperName);
+      expect(sendResult?.sessionId).to.equal(sessionId);
 
       const endResult = execCmd<AgentPreviewEndResult>(
         `agent preview end --session-id ${sessionId} --api-name ${


### PR DESCRIPTION
Add agentApiName field to JSON output for both agent preview start and send commands. Also add sessionId to agent preview send output. This helps AI agents maintain context about which agent they are working with during preview sessions without needing to use search tools to find trace files.

Changes:
- agent preview start: returns {sessionId, agentApiName}
- agent preview send: returns {messages, agentApiName, sessionId}
- Updated JSON schemas for both commands
- Added test assertions in NUT tests

Work Item: W-22203665

### What does this PR do?

### What issues does this PR fix or reference?
