### PR TITLE
W-22203672: add hidden --agent-json flag to agent preview start

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -92,6 +92,7 @@
     "flagAliases": [],
     "flagChars": ["d", "n", "o", "x"],
     "flags": [
+      "agent-json",
       "apex-debug",
       "api-name",
       "api-version",
@@ -142,6 +143,7 @@
     "flagAliases": [],
     "flagChars": ["n", "o"],
     "flags": [
+      "agent-json",
       "api-name",
       "api-version",
       "authoring-bundle",

--- a/messages/agent.preview.md
+++ b/messages/agent.preview.md
@@ -39,6 +39,10 @@ Use real actions in the org; if not specified, preview uses AI to simulate (mock
 
 Enable Apex debug logging during the agent preview conversation.
 
+# flags.agent-json.summary
+
+Path to a pre-compiled AgentJSON file to use instead of compiling the Agent Script file. Intended for internal use and testing.
+
 # examples
 
 - Preview an agent by choosing from the list of available local Agent Script or published agents. If previewing a local Agent Script agent, use simulated mode. Use the org with alias "my-dev-org".

--- a/messages/agent.preview.start.md
+++ b/messages/agent.preview.start.md
@@ -23,6 +23,10 @@ API name of the activated published agent you want to preview.
 
 API name of the authoring bundle metadata component that contains the agent's Agent Script file.
 
+# flags.agent-json.summary
+
+Path to a pre-compiled AgentJSON file to use instead of compiling the agent script. Intended for internal use and testing.
+
 # flags.use-live-actions.summary
 
 Execute real actions in the org (Apex classes, flows, etc.). Required with --authoring-bundle.

--- a/messages/agent.preview.start.md
+++ b/messages/agent.preview.start.md
@@ -25,7 +25,7 @@ API name of the authoring bundle metadata component that contains the agent's Ag
 
 # flags.agent-json.summary
 
-Path to a pre-compiled AgentJSON file to use instead of compiling the agent script. Intended for internal use and testing.
+Path to a pre-compiled AgentJSON file to use instead of compiling the Agent Script file. Intended for internal use and testing.
 
 # flags.use-live-actions.summary
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@inquirer/prompts": "^7.10.1",
     "@oclif/core": "^4",
     "@oclif/multi-stage-output": "^0.8.36",
-    "@salesforce/agents": "^1.2.0",
+    "@salesforce/agents": "^1.3.0",
     "@salesforce/core": "^8.28.3",
     "@salesforce/kit": "^3.2.6",
     "@salesforce/sf-plugins-core": "^12.2.6",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@inquirer/prompts": "^7.10.1",
     "@oclif/core": "^4",
     "@oclif/multi-stage-output": "^0.8.36",
-    "@salesforce/agents": "^1.3.0",
+    "@salesforce/agents": "^1.4.0",
     "@salesforce/core": "^8.28.3",
     "@salesforce/kit": "^3.2.6",
     "@salesforce/sf-plugins-core": "^12.2.6",

--- a/src/commands/agent/preview.ts
+++ b/src/commands/agent/preview.ts
@@ -105,8 +105,14 @@ export default class AgentPreview extends SfCommand<AgentPreviewResult> {
 
     if (aabName) {
       // user specified --authoring-bundle, use the API name directly
-      selectedAgent = await Agent.init({ connection: conn, project: this.project!, aabName, agentJson: preloadedAgentJson });
-      selectedAgent.preview.setMockMode(flags['use-live-actions'] ? 'Live Test' : 'Mock');
+      const scriptAgent = await Agent.init({
+        connection: conn,
+        project: this.project!,
+        aabName,
+        agentJson: preloadedAgentJson,
+      });
+      scriptAgent.preview.setMockMode(flags['use-live-actions'] ? 'Live Test' : 'Mock');
+      selectedAgent = scriptAgent;
     } else if (apiNameOrId) {
       selectedAgent = await Agent.init({ connection: conn, project: this.project!, apiNameOrId });
     } else {

--- a/src/commands/agent/preview.ts
+++ b/src/commands/agent/preview.ts
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
+import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { Flags, SfCommand } from '@salesforce/sf-plugins-core';
 import React from 'react';
 import { render } from 'ink';
-import { Agent, AgentSource, PreviewableAgent, ProductionAgent, ScriptAgent } from '@salesforce/agents';
+import { Agent, AgentSource, PreviewableAgent, ProductionAgent, ScriptAgent, type AgentJson } from '@salesforce/agents';
 import { select } from '@inquirer/prompts';
 import { Lifecycle, Messages, SfError } from '@salesforce/core';
 import { AgentPreviewReact } from '../../components/agent-preview-react.js';
@@ -69,6 +70,12 @@ export default class AgentPreview extends SfCommand<AgentPreviewResult> {
       summary: messages.getMessage('flags.use-live-actions.summary'),
       default: false,
     }),
+    'agent-json': Flags.file({
+      summary: messages.getMessage('flags.agent-json.summary'),
+      hidden: true,
+      exists: true,
+      dependsOn: ['authoring-bundle'],
+    }),
   };
 
   public async run(): Promise<AgentPreviewResult> {
@@ -81,11 +88,24 @@ export default class AgentPreview extends SfCommand<AgentPreviewResult> {
     const { 'api-name': apiNameOrId, 'use-live-actions': useLiveActions, 'authoring-bundle': aabName } = flags;
     const conn = flags['target-org'].getConnection(flags['api-version']);
 
+    let preloadedAgentJson: AgentJson | undefined;
+    if (flags['agent-json']) {
+      try {
+        preloadedAgentJson = JSON.parse(await readFile(flags['agent-json'], 'utf-8')) as AgentJson;
+      } catch (error) {
+        await Lifecycle.getInstance().emitTelemetry({ eventName: 'agent_preview_agent_json_read_failed' });
+        throw new SfError(
+          `Failed to read or parse --agent-json file '${flags['agent-json']}': ${SfError.wrap(error).message}`,
+          'AgentJsonReadError'
+        );
+      }
+    }
+
     let selectedAgent: ScriptAgent | ProductionAgent;
 
     if (aabName) {
       // user specified --authoring-bundle, use the API name directly
-      selectedAgent = await Agent.init({ connection: conn, project: this.project!, aabName });
+      selectedAgent = await Agent.init({ connection: conn, project: this.project!, aabName, agentJson: preloadedAgentJson });
       selectedAgent.preview.setMockMode(flags['use-live-actions'] ? 'Live Test' : 'Mock');
     } else if (apiNameOrId) {
       selectedAgent = await Agent.init({ connection: conn, project: this.project!, apiNameOrId });

--- a/src/commands/agent/preview.ts
+++ b/src/commands/agent/preview.ts
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { Flags, SfCommand } from '@salesforce/sf-plugins-core';
 import React from 'react';
 import { render } from 'ink';
-import { Agent, AgentSource, PreviewableAgent, ProductionAgent, ScriptAgent, type AgentJson } from '@salesforce/agents';
+import { Agent, AgentSource, PreviewableAgent, ProductionAgent, ScriptAgent } from '@salesforce/agents';
 import { select } from '@inquirer/prompts';
 import { Lifecycle, Messages, SfError } from '@salesforce/core';
 import { AgentPreviewReact } from '../../components/agent-preview-react.js';
+import { loadAgentJson } from '../../common.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-agent', 'agent.preview');
@@ -88,18 +88,7 @@ export default class AgentPreview extends SfCommand<AgentPreviewResult> {
     const { 'api-name': apiNameOrId, 'use-live-actions': useLiveActions, 'authoring-bundle': aabName } = flags;
     const conn = flags['target-org'].getConnection(flags['api-version']);
 
-    let preloadedAgentJson: AgentJson | undefined;
-    if (flags['agent-json']) {
-      try {
-        preloadedAgentJson = JSON.parse(await readFile(flags['agent-json'], 'utf-8')) as AgentJson;
-      } catch (error) {
-        await Lifecycle.getInstance().emitTelemetry({ eventName: 'agent_preview_agent_json_read_failed' });
-        throw new SfError(
-          `Failed to read or parse --agent-json file '${flags['agent-json']}': ${SfError.wrap(error).message}`,
-          'AgentJsonReadError'
-        );
-      }
-    }
+    const preloadedAgentJson = await loadAgentJson(flags['agent-json']);
 
     let selectedAgent: ScriptAgent | ProductionAgent;
 

--- a/src/commands/agent/preview/start.ts
+++ b/src/commands/agent/preview/start.ts
@@ -73,6 +73,7 @@ export default class AgentPreviewStart extends SfCommand<AgentPreviewStartResult
       summary: messages.getMessage('flags.agent-json.summary'),
       hidden: true,
       exists: true,
+      dependsOn: ['authoring-bundle'],
     }),
   };
 
@@ -191,6 +192,7 @@ async function loadAgentJson(filePath: string | undefined): Promise<AgentJson | 
   try {
     return JSON.parse(await readFile(filePath, 'utf-8')) as AgentJson;
   } catch (error) {
+    await Lifecycle.getInstance().emitTelemetry({ eventName: 'agent_preview_start_agent_json_read_failed' });
     throw new SfError(
       `Failed to read or parse --agent-json file '${filePath}': ${SfError.wrap(error).message}`,
       'AgentJsonReadError'

--- a/src/commands/agent/preview/start.ts
+++ b/src/commands/agent/preview/start.ts
@@ -99,14 +99,16 @@ export default class AgentPreviewStart extends SfCommand<AgentPreviewStartResult
     // Track telemetry for agent initialization
     let agent: ScriptAgent | ProductionAgent;
     try {
-      agent = flags['authoring-bundle']
-        ? await Agent.init({
-            connection: conn,
-            project: this.project!,
-            aabName: flags['authoring-bundle'],
-            agentJson: preloadedAgentJson,
-          })
-        : await Agent.init({ connection: conn, project: this.project!, apiNameOrId: flags['api-name']! });
+      if (flags['authoring-bundle']) {
+        agent = await Agent.init({
+          connection: conn,
+          project: this.project!,
+          aabName: flags['authoring-bundle'],
+          agentJson: preloadedAgentJson,
+        });
+      } else {
+        agent = await Agent.init({ connection: conn, project: this.project!, apiNameOrId: flags['api-name']! });
+      }
     } catch (error) {
       const wrapped = SfError.wrap(error);
 
@@ -145,7 +147,8 @@ export default class AgentPreviewStart extends SfCommand<AgentPreviewStartResult
     // Set mode for authoring bundles based on which flag was specified
     // (mutual exclusion enforced by flag definitions - can't have both)
     if (agent instanceof ScriptAgent) {
-      agent.preview.setMockMode(simulateActions ? 'Mock' : 'Live Test');
+      const scriptAgent: ScriptAgent = agent;
+      scriptAgent.preview.setMockMode(simulateActions ? 'Mock' : 'Live Test');
     }
 
     // Warn if mode flags are used with published agents (they have no effect)

--- a/src/commands/agent/preview/start.ts
+++ b/src/commands/agent/preview/start.ts
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-import { readFile } from 'node:fs/promises';
 import { Flags, SfCommand, toHelpSection } from '@salesforce/sf-plugins-core';
 import { EnvironmentVariable, Lifecycle, Messages, SfError } from '@salesforce/core';
-import { Agent, ProductionAgent, ScriptAgent, type AgentJson } from '@salesforce/agents';
+import { Agent, ProductionAgent, ScriptAgent } from '@salesforce/agents';
 import { createCache, SessionType } from '../../../previewSessionStore.js';
-import { COMPILATION_API_EXIT_CODES } from '../../../common.js';
+import { COMPILATION_API_EXIT_CODES, loadAgentJson } from '../../../common.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-agent', 'agent.preview.start');
@@ -147,8 +146,7 @@ export default class AgentPreviewStart extends SfCommand<AgentPreviewStartResult
     // Set mode for authoring bundles based on which flag was specified
     // (mutual exclusion enforced by flag definitions - can't have both)
     if (agent instanceof ScriptAgent) {
-      const scriptAgent: ScriptAgent = agent;
-      scriptAgent.preview.setMockMode(simulateActions ? 'Mock' : 'Live Test');
+      agent.preview.setMockMode(simulateActions ? 'Mock' : 'Live Test');
     }
 
     // Warn if mode flags are used with published agents (they have no effect)
@@ -188,17 +186,4 @@ export default class AgentPreviewStart extends SfCommand<AgentPreviewStartResult
 function resolveSessionType(agent: ScriptAgent | ProductionAgent, simulateActions: boolean | undefined): SessionType {
   if (agent instanceof ProductionAgent) return 'published';
   return simulateActions ? 'simulated' : 'live';
-}
-
-async function loadAgentJson(filePath: string | undefined): Promise<AgentJson | undefined> {
-  if (!filePath) return undefined;
-  try {
-    return JSON.parse(await readFile(filePath, 'utf-8')) as AgentJson;
-  } catch (error) {
-    await Lifecycle.getInstance().emitTelemetry({ eventName: 'agent_preview_start_agent_json_read_failed' });
-    throw new SfError(
-      `Failed to read or parse --agent-json file '${filePath}': ${SfError.wrap(error).message}`,
-      'AgentJsonReadError'
-    );
-  }
 }

--- a/src/commands/agent/preview/start.ts
+++ b/src/commands/agent/preview/start.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
+import { readFile } from 'node:fs/promises';
 import { Flags, SfCommand, toHelpSection } from '@salesforce/sf-plugins-core';
 import { EnvironmentVariable, Lifecycle, Messages, SfError } from '@salesforce/core';
-import { Agent, ProductionAgent, ScriptAgent } from '@salesforce/agents';
+import { Agent, ProductionAgent, ScriptAgent, type AgentJson } from '@salesforce/agents';
 import { createCache, SessionType } from '../../../previewSessionStore.js';
 import { COMPILATION_API_EXIT_CODES } from '../../../common.js';
 
@@ -68,6 +69,11 @@ export default class AgentPreviewStart extends SfCommand<AgentPreviewStartResult
       summary: messages.getMessage('flags.simulate-actions.summary'),
       exclusive: ['use-live-actions'],
     }),
+    'agent-json': Flags.file({
+      summary: messages.getMessage('flags.agent-json.summary'),
+      hidden: true,
+      exists: true,
+    }),
   };
 
   public async run(): Promise<AgentPreviewStartResult> {
@@ -87,11 +93,18 @@ export default class AgentPreviewStart extends SfCommand<AgentPreviewStartResult
     const simulateActions = flags['simulate-actions'];
     const agentIdentifier = flags['authoring-bundle'] ?? flags['api-name']!;
 
+    const preloadedAgentJson = await loadAgentJson(flags['agent-json']);
+
     // Track telemetry for agent initialization
     let agent: ScriptAgent | ProductionAgent;
     try {
       agent = flags['authoring-bundle']
-        ? await Agent.init({ connection: conn, project: this.project!, aabName: flags['authoring-bundle'] })
+        ? await Agent.init({
+            connection: conn,
+            project: this.project!,
+            aabName: flags['authoring-bundle'],
+            agentJson: preloadedAgentJson,
+          })
         : await Agent.init({ connection: conn, project: this.project!, apiNameOrId: flags['api-name']! });
     } catch (error) {
       const wrapped = SfError.wrap(error);
@@ -171,4 +184,16 @@ export default class AgentPreviewStart extends SfCommand<AgentPreviewStartResult
 function resolveSessionType(agent: ScriptAgent | ProductionAgent, simulateActions: boolean | undefined): SessionType {
   if (agent instanceof ProductionAgent) return 'published';
   return simulateActions ? 'simulated' : 'live';
+}
+
+async function loadAgentJson(filePath: string | undefined): Promise<AgentJson | undefined> {
+  if (!filePath) return undefined;
+  try {
+    return JSON.parse(await readFile(filePath, 'utf-8')) as AgentJson;
+  } catch (error) {
+    throw new SfError(
+      `Failed to read or parse --agent-json file '${filePath}': ${SfError.wrap(error).message}`,
+      'AgentJsonReadError'
+    );
+  }
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -13,12 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { readFile } from 'node:fs/promises';
 import { EOL } from 'node:os';
-import { SfError } from '@salesforce/core';
-import { CompilationError, COMPILATION_API_EXIT_CODES } from '@salesforce/agents';
+import { Lifecycle, SfError } from '@salesforce/core';
+import { CompilationError, COMPILATION_API_EXIT_CODES, type AgentJson } from '@salesforce/agents';
 
 /** Re-export so consumers can use the library's exit code contract (404 → 2, 500 → 3). */
 export { COMPILATION_API_EXIT_CODES };
+
+export async function loadAgentJson(filePath: string | undefined): Promise<AgentJson | undefined> {
+  if (!filePath) return undefined;
+  try {
+    return JSON.parse(await readFile(filePath, 'utf-8')) as AgentJson;
+  } catch (error) {
+    await Lifecycle.getInstance().emitTelemetry({ eventName: 'agent_preview_agent_json_read_failed' });
+    throw new SfError(
+      `Failed to read or parse --agent-json file '${filePath}': ${SfError.wrap(error).message}`,
+      'AgentJsonReadError'
+    );
+  }
+}
 
 /**
  * Utility function to generate SfError when there are agent compilation errors.

--- a/test/commands/agent/preview/start.test.ts
+++ b/test/commands/agent/preview/start.test.ts
@@ -16,6 +16,8 @@
 
 /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any */
 
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { expect } from 'chai';
 import sinon from 'sinon';
@@ -74,6 +76,109 @@ describe('agent preview start', () => {
 
   afterEach(() => {
     $$.restore();
+  });
+
+  describe('--agent-json flag', () => {
+    const mockAgentJson = {
+      schemaVersion: '1.0',
+      globalConfiguration: {
+        developerName: 'TestAgent',
+        label: 'Test Agent',
+        description: '',
+        enableEnhancedEventLogs: false,
+        agentType: 'AgentforceServiceAgent',
+        templateName: '',
+        defaultAgentUser: 'test@user.com',
+        defaultOutboundRouting: '',
+        contextVariables: [],
+      },
+      agentVersion: {
+        developerName: null,
+        plannerType: 'ReAct',
+        systemMessages: [],
+        modalityParameters: { voice: {}, language: {} },
+        additionalParameters: false,
+        company: 'Test',
+        role: 'Assistant',
+        stateVariables: [],
+        initialNode: 'start',
+        nodes: [],
+        knowledgeDefinitions: null,
+      },
+    };
+    let agentJsonInitStub: sinon.SinonStub;
+    let AgentPreviewStartWithFileFlag: any;
+    let tmpDir: string;
+
+    beforeEach(async () => {
+      tmpDir = mkdtempSync(join(tmpdir(), 'agent-json-test-'));
+
+      const mockPreview = {
+        setMockMode: $$.SANDBOX.stub(),
+        start: $$.SANDBOX.stub().resolves({ sessionId: 'test-session-id' }),
+      };
+      class MockScriptAgent {
+        public preview = mockPreview;
+        public name = 'TestAgent';
+      }
+      agentJsonInitStub = $$.SANDBOX.stub().resolves(new MockScriptAgent());
+
+      const mod = await esmock('../../../../src/commands/agent/preview/start.js', {
+        '@salesforce/agents': {
+          Agent: { init: agentJsonInitStub },
+          ScriptAgent: MockScriptAgent,
+          ProductionAgent: class ProductionAgent {},
+        },
+        '../../../../src/previewSessionStore.js': {
+          createCache: $$.SANDBOX.stub().resolves(),
+        },
+      });
+      AgentPreviewStartWithFileFlag = mod.default;
+    });
+
+    afterEach(() => {
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('reads the file and passes parsed agentJson to Agent.init', async () => {
+      const agentJsonPath = join(tmpDir, 'agent.json');
+      writeFileSync(agentJsonPath, JSON.stringify(mockAgentJson));
+
+      await AgentPreviewStartWithFileFlag.run([
+        '--authoring-bundle',
+        'MyAgent',
+        '--simulate-actions',
+        '--target-org',
+        'test@org.com',
+        '--agent-json',
+        agentJsonPath,
+      ]);
+
+      expect(agentJsonInitStub.calledOnce).to.be.true;
+      const initArg = agentJsonInitStub.firstCall.args[0];
+      expect(initArg).to.have.property('agentJson');
+      expect(initArg.agentJson).to.deep.equal(mockAgentJson);
+    });
+
+    it('throws AgentJsonReadError when file contains invalid JSON', async () => {
+      const badJsonPath = join(tmpDir, 'bad.json');
+      writeFileSync(badJsonPath, 'not-valid-json{{{');
+
+      try {
+        await AgentPreviewStartWithFileFlag.run([
+          '--authoring-bundle',
+          'MyAgent',
+          '--simulate-actions',
+          '--target-org',
+          'test@org.com',
+          '--agent-json',
+          badJsonPath,
+        ]);
+        expect.fail('Should have thrown');
+      } catch (error: unknown) {
+        expect((error as Error).message).to.include('Failed to read or parse --agent-json file');
+      }
+    });
   });
 
   describe('setMockMode', () => {

--- a/test/nuts/fixtures/compiled-agent.json
+++ b/test/nuts/fixtures/compiled-agent.json
@@ -1,0 +1,60 @@
+{
+  "schemaVersion": "1.0",
+  "globalConfiguration": {
+    "developerName": "Willie_Resort_Manager",
+    "label": "Willie Resort Manager",
+    "description": "A resort manager agent for NUT testing",
+    "enableEnhancedEventLogs": false,
+    "agentType": "AgentforceAgent",
+    "templateName": "",
+    "defaultAgentUser": "",
+    "defaultOutboundRouting": "",
+    "contextVariables": []
+  },
+  "agentVersion": {
+    "developerName": null,
+    "plannerType": "ReAct",
+    "systemMessages": [],
+    "modalityParameters": {
+      "voice": {
+        "inboundModel": null,
+        "inboundFillerWordsDetection": null,
+        "outboundVoice": null,
+        "outboundModel": null,
+        "outboundSpeed": null,
+        "outboundStyleExaggeration": null
+      },
+      "language": {
+        "defaultLocale": "en_US",
+        "additionalLocales": [],
+        "allAdditionalLocales": false
+      }
+    },
+    "additionalParameters": false,
+    "company": "Willie Resort",
+    "role": "A helpful resort management assistant",
+    "stateVariables": [],
+    "initialNode": "MainNode",
+    "nodes": [
+      {
+        "type": "Reasoning",
+        "reasoningType": "ReAct",
+        "description": "Main reasoning node",
+        "beforeReasoning": "",
+        "instructions": "Help users manage resort bookings and inquiries.",
+        "focusPrompt": "",
+        "tools": [],
+        "preToolCall": null,
+        "postToolCall": null,
+        "afterReasoning": null,
+        "developerName": "MainNode",
+        "label": "Main Node",
+        "onInit": null,
+        "transitions": null,
+        "onExit": null,
+        "actionDefinitions": []
+      }
+    ],
+    "knowledgeDefinitions": null
+  }
+}

--- a/test/nuts/fixtures/compiled-agent.json
+++ b/test/nuts/fixtures/compiled-agent.json
@@ -5,7 +5,7 @@
     "label": "Willie Resort Manager",
     "description": "A resort manager agent for NUT testing",
     "enableEnhancedEventLogs": false,
-    "agentType": "AgentforceAgent",
+    "agentType": "customer",
     "templateName": "",
     "defaultAgentUser": "",
     "defaultOutboundRouting": "",

--- a/test/nuts/fixtures/compiled-agent.json
+++ b/test/nuts/fixtures/compiled-agent.json
@@ -5,7 +5,7 @@
     "label": "Willie Resort Manager",
     "description": "A resort manager agent for NUT testing",
     "enableEnhancedEventLogs": false,
-    "agentType": "AgentforceServiceAgent",
+    "agentType": "EinsteinServiceAgent",
     "templateName": "",
     "defaultAgentUser": "",
     "defaultOutboundRouting": "",

--- a/test/nuts/fixtures/compiled-agent.json
+++ b/test/nuts/fixtures/compiled-agent.json
@@ -5,7 +5,7 @@
     "label": "Willie Resort Manager",
     "description": "A resort manager agent for NUT testing",
     "enableEnhancedEventLogs": false,
-    "agentType": "customer",
+    "agentType": "AgentforceServiceAgent",
     "templateName": "",
     "defaultAgentUser": "",
     "defaultOutboundRouting": "",

--- a/test/nuts/z3.agent.preview.nut.ts
+++ b/test/nuts/z3.agent.preview.nut.ts
@@ -26,7 +26,7 @@ import { Org } from '@salesforce/core';
 import type { AgentPreviewStartResult } from '../../src/commands/agent/preview/start.js';
 import type { AgentPreviewSendResult } from '../../src/commands/agent/preview/send.js';
 import type { AgentPreviewEndResult } from '../../src/commands/agent/preview/end.js';
-import { getAgentUsername, getTestSession, getUsername } from './shared-setup.js';
+import { getTestSession, getUsername } from './shared-setup.js';
 /* eslint-disable no-console */
 
 describe('agent preview', function () {
@@ -59,14 +59,11 @@ describe('agent preview', function () {
 
       // Use a static fixture instead of hitting the compile API, which avoids a
       // live network call that can fail independently of the feature under test.
-      // Patch defaultAgentUser so bypassUser resolves correctly in the org.
+      // Leave defaultAgentUser empty so the library sends bypassUser=false,
+      // which skips the permission-set validation that causes a 500.
       const fixtureSource = join(fileURLToPath(import.meta.url), '..', 'fixtures', 'compiled-agent.json');
-      const fixtureJson = JSON.parse(readFileSync(fixtureSource, 'utf-8')) as {
-        globalConfiguration: { defaultAgentUser: string };
-      };
-      fixtureJson.globalConfiguration.defaultAgentUser = getAgentUsername() ?? '';
       const agentJsonPath = join(tmpDir, 'compiled-agent.json');
-      writeFileSync(agentJsonPath, JSON.stringify(fixtureJson));
+      writeFileSync(agentJsonPath, readFileSync(fixtureSource));
 
       const startCmdResult = execCmd<AgentPreviewStartResult>(
         `agent preview start --authoring-bundle ${bundleApiName} --simulate-actions --agent-json "${agentJsonPath}" --target-org ${targetOrg} --json`,

--- a/test/nuts/z3.agent.preview.nut.ts
+++ b/test/nuts/z3.agent.preview.nut.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { writeFileSync, rmSync } from 'node:fs';
+import { writeFileSync, rmSync, readFileSync } from 'node:fs';
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -26,7 +26,7 @@ import { Org } from '@salesforce/core';
 import type { AgentPreviewStartResult } from '../../src/commands/agent/preview/start.js';
 import type { AgentPreviewSendResult } from '../../src/commands/agent/preview/send.js';
 import type { AgentPreviewEndResult } from '../../src/commands/agent/preview/end.js';
-import { getTestSession, getUsername } from './shared-setup.js';
+import { getAgentUsername, getTestSession, getUsername } from './shared-setup.js';
 /* eslint-disable no-console */
 
 describe('agent preview', function () {
@@ -59,7 +59,14 @@ describe('agent preview', function () {
 
       // Use a static fixture instead of hitting the compile API, which avoids a
       // live network call that can fail independently of the feature under test.
-      const agentJsonPath = join(fileURLToPath(import.meta.url), '..', 'fixtures', 'compiled-agent.json');
+      // Patch defaultAgentUser so bypassUser resolves correctly in the org.
+      const fixtureSource = join(fileURLToPath(import.meta.url), '..', 'fixtures', 'compiled-agent.json');
+      const fixtureJson = JSON.parse(readFileSync(fixtureSource, 'utf-8')) as {
+        globalConfiguration: { defaultAgentUser: string };
+      };
+      fixtureJson.globalConfiguration.defaultAgentUser = getAgentUsername() ?? '';
+      const agentJsonPath = join(tmpDir, 'compiled-agent.json');
+      writeFileSync(agentJsonPath, JSON.stringify(fixtureJson));
 
       const startResult = execCmd<AgentPreviewStartResult>(
         `agent preview start --authoring-bundle ${bundleApiName} --simulate-actions --agent-json ${agentJsonPath} --target-org ${targetOrg} --json`,

--- a/test/nuts/z3.agent.preview.nut.ts
+++ b/test/nuts/z3.agent.preview.nut.ts
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+import { writeFileSync, rmSync } from 'node:fs';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { expect } from 'chai';
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
 import { Agent } from '@salesforce/agents';
@@ -33,6 +37,77 @@ describe('agent preview', function () {
   before(async function () {
     this.timeout(30 * 60 * 1000); // 30 minutes for setup
     session = await getTestSession();
+  });
+
+  describe('--agent-json flag', () => {
+    let tmpDir: string;
+
+    before(() => {
+      tmpDir = mkdtempSync(join(tmpdir(), 'agent-json-nut-'));
+    });
+
+    after(() => {
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('should start a preview session using a pre-compiled AgentJSON file', async function () {
+      this.timeout(5 * 60 * 1000);
+
+      const bundleApiName = 'Willie_Resort_Manager';
+      const targetOrg = getUsername();
+
+      // Compile agent JSON first via preview start (compile happens internally), then reuse it
+      // For the NUT we write a minimal valid agentJson extracted from a successful compile
+      const org = await Org.create({ aliasOrUsername: targetOrg });
+      const conn = org.getConnection();
+      const { ScriptAgent: ScriptAgentClass } = await import('@salesforce/agents');
+      const { SfProject } = await import('@salesforce/core');
+      const project = await SfProject.resolve(session.project.dir);
+      const scriptAgent = new ScriptAgentClass({ connection: conn, project, aabName: bundleApiName });
+      await scriptAgent.compile();
+
+      // @ts-expect-error accessing private field for NUT purposes
+      const agentJson = scriptAgent.agentJson as object;
+      expect(agentJson).to.not.be.undefined;
+
+      const agentJsonPath = join(tmpDir, 'compiled-agent.json');
+      writeFileSync(agentJsonPath, JSON.stringify(agentJson));
+
+      const startResult = execCmd<AgentPreviewStartResult>(
+        `agent preview start --authoring-bundle ${bundleApiName} --simulate-actions --agent-json ${agentJsonPath} --target-org ${targetOrg} --json`,
+        { cwd: session.project.dir }
+      ).jsonOutput?.result;
+
+      expect(startResult?.sessionId).to.be.a('string');
+      expect(startResult?.agentApiName).to.equal(bundleApiName);
+
+      // Clean up session
+      execCmd(
+        `agent preview end --session-id ${startResult!.sessionId} --authoring-bundle ${bundleApiName} --target-org ${targetOrg} --json`,
+        { cwd: session.project.dir }
+      );
+    });
+
+    it('should fail when --agent-json contains invalid JSON', () => {
+      const badJsonPath = join(tmpDir, 'bad.json');
+      writeFileSync(badJsonPath, 'not-valid{{{');
+
+      const result = execCmd(
+        `agent preview start --authoring-bundle Willie_Resort_Manager --simulate-actions --agent-json ${badJsonPath} --target-org ${getUsername()} --json`,
+        { ensureExitCode: 1, cwd: session.project.dir }
+      );
+      expect(JSON.stringify(result.shellOutput)).to.include('Failed to read or parse');
+    });
+
+    it('should fail when --agent-json is used without --authoring-bundle', () => {
+      const agentJsonPath = join(tmpDir, 'any.json');
+      writeFileSync(agentJsonPath, '{}');
+
+      execCmd(
+        `agent preview start --api-name Some_Agent --agent-json ${agentJsonPath} --target-org ${getUsername()} --json`,
+        { ensureExitCode: 2 }
+      );
+    });
   });
 
   it('should fail when authoring bundle does not exist', async () => {

--- a/test/nuts/z3.agent.preview.nut.ts
+++ b/test/nuts/z3.agent.preview.nut.ts
@@ -14,15 +14,14 @@
  * limitations under the License.
  */
 
-import { writeFileSync, rmSync, readFileSync } from 'node:fs';
+import { writeFileSync, rmSync } from 'node:fs';
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { expect } from 'chai';
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
 import { Agent } from '@salesforce/agents';
-import { Org } from '@salesforce/core';
+import { Org, SfProject } from '@salesforce/core';
 import type { AgentPreviewStartResult } from '../../src/commands/agent/preview/start.js';
 import type { AgentPreviewSendResult } from '../../src/commands/agent/preview/send.js';
 import type { AgentPreviewEndResult } from '../../src/commands/agent/preview/end.js';
@@ -57,13 +56,20 @@ describe('agent preview', function () {
       const bundleApiName = 'Willie_Resort_Manager';
       const targetOrg = getUsername();
 
-      // Use a static fixture instead of hitting the compile API, which avoids a
-      // live network call that can fail independently of the feature under test.
-      // Leave defaultAgentUser empty so the library sends bypassUser=false,
-      // which skips the permission-set validation that causes a 500.
-      const fixtureSource = join(fileURLToPath(import.meta.url), '..', 'fixtures', 'compiled-agent.json');
+      // Compile the agent once to get a valid agentJson, write it to a temp file,
+      // then pass it back via --agent-json. This tests the flag plumbing (the
+      // command must accept a pre-compiled file and skip recompilation) while
+      // ensuring the fixture matches what the preview sessions API actually accepts.
+      const org = await Org.create({ aliasOrUsername: targetOrg });
+      const conn = org.getConnection();
+      const project = await SfProject.resolve(session.project.dir);
+      const agent = await Agent.init({ connection: conn, project, aabName: bundleApiName });
+      const compileResult = await agent.compile();
+      if (compileResult.status !== 'success' || !compileResult.compiledArtifact) {
+        throw new Error(`Compile failed: ${JSON.stringify(compileResult)}`);
+      }
       const agentJsonPath = join(tmpDir, 'compiled-agent.json');
-      writeFileSync(agentJsonPath, readFileSync(fixtureSource));
+      writeFileSync(agentJsonPath, JSON.stringify(compileResult.compiledArtifact));
 
       const startCmdResult = execCmd<AgentPreviewStartResult>(
         `agent preview start --authoring-bundle ${bundleApiName} --simulate-actions --agent-json "${agentJsonPath}" --target-org ${targetOrg} --json`,

--- a/test/nuts/z3.agent.preview.nut.ts
+++ b/test/nuts/z3.agent.preview.nut.ts
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-import { writeFileSync, rmSync } from 'node:fs';
+import { writeFileSync, rmSync, readFileSync } from 'node:fs';
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { expect } from 'chai';
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
 import { Agent } from '@salesforce/agents';
@@ -56,22 +57,11 @@ describe('agent preview', function () {
       const bundleApiName = 'Willie_Resort_Manager';
       const targetOrg = getUsername();
 
-      // Compile agent JSON first via preview start (compile happens internally), then reuse it
-      // For the NUT we write a minimal valid agentJson extracted from a successful compile
-      const org = await Org.create({ aliasOrUsername: targetOrg });
-      const conn = org.getConnection();
-      const { ScriptAgent: ScriptAgentClass } = await import('@salesforce/agents');
-      const { SfProject } = await import('@salesforce/core');
-      const project = await SfProject.resolve(session.project.dir);
-      const scriptAgent = new ScriptAgentClass({ connection: conn, project, aabName: bundleApiName });
-      await scriptAgent.compile();
-
-      // @ts-expect-error accessing private field for NUT purposes
-      const agentJson = scriptAgent.agentJson as object;
-      expect(agentJson).to.not.be.undefined;
-
+      // Use a static fixture instead of hitting the compile API, which avoids a
+      // live network call that can fail independently of the feature under test.
+      const fixtureDir = join(fileURLToPath(import.meta.url), '..', 'fixtures');
       const agentJsonPath = join(tmpDir, 'compiled-agent.json');
-      writeFileSync(agentJsonPath, JSON.stringify(agentJson));
+      writeFileSync(agentJsonPath, readFileSync(join(fixtureDir, 'compiled-agent.json')));
 
       const startResult = execCmd<AgentPreviewStartResult>(
         `agent preview start --authoring-bundle ${bundleApiName} --simulate-actions --agent-json ${agentJsonPath} --target-org ${targetOrg} --json`,
@@ -83,7 +73,9 @@ describe('agent preview', function () {
 
       // Clean up session
       execCmd(
-        `agent preview end --session-id ${startResult!.sessionId} --authoring-bundle ${bundleApiName} --target-org ${targetOrg} --json`,
+        `agent preview end --session-id ${
+          startResult!.sessionId
+        } --authoring-bundle ${bundleApiName} --target-org ${targetOrg} --json`,
         { cwd: session.project.dir }
       );
     });

--- a/test/nuts/z3.agent.preview.nut.ts
+++ b/test/nuts/z3.agent.preview.nut.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { writeFileSync, rmSync, readFileSync } from 'node:fs';
+import { writeFileSync, rmSync } from 'node:fs';
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -59,9 +59,7 @@ describe('agent preview', function () {
 
       // Use a static fixture instead of hitting the compile API, which avoids a
       // live network call that can fail independently of the feature under test.
-      const fixtureDir = join(fileURLToPath(import.meta.url), '..', 'fixtures');
-      const agentJsonPath = join(tmpDir, 'compiled-agent.json');
-      writeFileSync(agentJsonPath, readFileSync(join(fixtureDir, 'compiled-agent.json')));
+      const agentJsonPath = join(fileURLToPath(import.meta.url), '..', 'fixtures', 'compiled-agent.json');
 
       const startResult = execCmd<AgentPreviewStartResult>(
         `agent preview start --authoring-bundle ${bundleApiName} --simulate-actions --agent-json ${agentJsonPath} --target-org ${targetOrg} --json`,

--- a/test/nuts/z3.agent.preview.nut.ts
+++ b/test/nuts/z3.agent.preview.nut.ts
@@ -68,10 +68,11 @@ describe('agent preview', function () {
       const agentJsonPath = join(tmpDir, 'compiled-agent.json');
       writeFileSync(agentJsonPath, JSON.stringify(fixtureJson));
 
-      const startResult = execCmd<AgentPreviewStartResult>(
-        `agent preview start --authoring-bundle ${bundleApiName} --simulate-actions --agent-json ${agentJsonPath} --target-org ${targetOrg} --json`,
-        { cwd: session.project.dir }
-      ).jsonOutput?.result;
+      const startCmdResult = execCmd<AgentPreviewStartResult>(
+        `agent preview start --authoring-bundle ${bundleApiName} --simulate-actions --agent-json "${agentJsonPath}" --target-org ${targetOrg} --json`,
+        { ensureExitCode: 0 }
+      );
+      const startResult = startCmdResult.jsonOutput?.result;
 
       expect(startResult?.sessionId).to.be.a('string');
       expect(startResult?.agentApiName).to.equal(bundleApiName);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1595,10 +1595,10 @@
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
-"@salesforce/agents@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@salesforce/agents/-/agents-1.2.0.tgz#6f360f824b80bd66e8ba561f98fe52bc62e24ab9"
-  integrity sha512-gyF1xzJcEp3MuS8Apf1eUGUvy41zq7HQqKPEhDIU6aUiowoewW/RI9LcPB0K7LPrGCIiARq4TYKlxf452HASqA==
+"@salesforce/agents@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/agents/-/agents-1.3.0.tgz#342f2790013978c6b8855df399bf58ad4b5e9aec"
+  integrity sha512-HuwVifaBXdPuabHrRrLdyuUDV600YDsuDPI0pxw6A/JCzCdwsOkExpzi/Zz7v8I7qnUGhX9uK1GSKsBLasSXSg==
   dependencies:
     "@salesforce/core" "^8.28.3"
     "@salesforce/kit" "^3.2.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1595,10 +1595,10 @@
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
-"@salesforce/agents@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@salesforce/agents/-/agents-1.3.0.tgz#342f2790013978c6b8855df399bf58ad4b5e9aec"
-  integrity sha512-HuwVifaBXdPuabHrRrLdyuUDV600YDsuDPI0pxw6A/JCzCdwsOkExpzi/Zz7v8I7qnUGhX9uK1GSKsBLasSXSg==
+"@salesforce/agents@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/agents/-/agents-1.4.0.tgz#69c3e3e9d29b9596aadf99f94774c9c8713e34ca"
+  integrity sha512-NaiGUSjcyK0Wsy0n5pFuouHqOYH1KJEpgm605NqCaiOMAA3zn0pWZDHE9I75ymGqpvOXSHGDFNrUhKYPain9ZA==
   dependencies:
     "@salesforce/core" "^8.28.3"
     "@salesforce/kit" "^3.2.6"


### PR DESCRIPTION
## Summary
@W-22203672@

- Add hidden `--agent-json` flag to `sf agent preview start` accepting a file path to a pre-compiled AgentJSON
- When provided, passes the parsed JSON to `ScriptAgent` via `ScriptAgentOptions`, skipping the compile step
- Adds `loadAgentJson()` helper to keep `run()` complexity within lint limits
- Add 2 new unit tests: happy path (parsed JSON passed to `Agent.init`) and error path (invalid JSON throws `AgentJsonReadError`)

## Dependencies
Depends on [forcedotcom/agents#271](https://github.com/forcedotcom/agents/pull/271) — `@salesforce/agents` must be bumped after that merges.

## Test plan
- [ ] `yarn test:only` passes (244 tests)
- [ ] Manually run `sf agent preview start --authoring-bundle MyAgent --simulate-actions --agent-json /path/to/compiled.json --target-org myOrg` and confirm session starts without a compile request

🤖 Generated with [Claude Code](https://claude.com/claude-code)