### PR TITLE
test: fix NUTs @W-22293348@

### DIFF
--- a/src/commands/agent/publish/authoring-bundle.ts
+++ b/src/commands/agent/publish/authoring-bundle.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { EOL } from 'node:os';
-import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
+import { SfCommand, Flags, toHelpSection } from '@salesforce/sf-plugins-core';
 import { MultiStageOutput } from '@oclif/multi-stage-output';
 import { Messages, Lifecycle, SfError } from '@salesforce/core';
 import { Agent } from '@salesforce/agents';
@@ -37,6 +37,11 @@ export default class AgentPublishAuthoringBundle extends SfCommand<AgentPublishA
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
   public static readonly requiresProject = true;
+
+  public static readonly errorCodes = toHelpSection('ERROR CODES', {
+    'Succeeded (0)': 'Agent published successfully without errors.',
+    'Failed (1)': 'Compilation errors found in the Agent Script file.',
+  });
 
   public static readonly flags = {
     'target-org': Flags.requiredOrg(),

--- a/test/nuts/z2.agent.publish.nut.ts
+++ b/test/nuts/z2.agent.publish.nut.ts
@@ -175,7 +175,7 @@ describe('agent publish authoring-bundle NUTs', function () {
 
     execCmd<AgentPublishAuthoringBundleResult>(
       `agent publish authoring-bundle --api-name ${invalidApiName} --target-org ${getUsername()} --json`,
-      { ensureExitCode: 2 }
+      { ensureExitCode: 1 }
     );
   });
 
@@ -193,8 +193,8 @@ describe('agent publish authoring-bundle NUTs', function () {
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       // We assert both the "publish failed" prefix and that it looks like a compilation issue.
-      expect(message).to.include("SyntaxError: Unexpected 'syem'");
-      expect(message).to.match(/Actual:\s*2\b|"exitCode"\s*:\s*2/);
+      expect(message).to.include('CompilationError: Invalid string');
+      expect(message).to.match(/Actual:\s*2\b|"exitCode"\s*:\s*1/);
     }
   });
 


### PR DESCRIPTION
### What does this PR do?
In this PR 398 we introduced a change that broke some NUTs. When the original PR was merged, these legitimate failures were masked by a server issues that made all test to failed. Now that the environment is stable, I've identified and resolved the underlying issues in the test suite.

The original change removed try/catch block that was unnecessarily altering error message handling. By removing this, the error output now aligns with error handling used across other commands.

### What issues does this PR fix or reference?
@W-22293348@