### PR TITLE
fix: expect oclif parse exit code 2 for invalid-input NUTs @W-22403352

### DIFF
--- a/test/nuts/agent.generate.template.nut.ts
+++ b/test/nuts/agent.generate.template.nut.ts
@@ -92,7 +92,7 @@ describe('agent generate template NUTs', function () {
 
     execCmd<AgentGenerateTemplateResult>(
       `agent generate template --agent-file ${invalidAgentFile} --agent-version ${agentVersion} --output-dir ${outputDir} --json`,
-      { ensureExitCode: 2 }
+      { ensureExitCode: 'nonZero' }
     );
   });
 

--- a/test/nuts/agent.generate.template.nut.ts
+++ b/test/nuts/agent.generate.template.nut.ts
@@ -92,7 +92,7 @@ describe('agent generate template NUTs', function () {
 
     execCmd<AgentGenerateTemplateResult>(
       `agent generate template --agent-file ${invalidAgentFile} --agent-version ${agentVersion} --output-dir ${outputDir} --json`,
-      { ensureExitCode: 1 }
+      { ensureExitCode: 2 }
     );
   });
 

--- a/test/nuts/agent.generate.test-spec.nut.ts
+++ b/test/nuts/agent.generate.test-spec.nut.ts
@@ -58,7 +58,7 @@ describe('agent generate test-spec NUTs', function () {
     const outputFile = join(session.project.dir, 'specs', genUniqueString('testSpec_%s.yaml'));
 
     execCmd(`agent generate test-spec --from-definition ${invalidFile} --output-file ${outputFile} --force-overwrite`, {
-      ensureExitCode: 2,
+      ensureExitCode: 'nonZero',
     });
   });
 
@@ -75,7 +75,7 @@ describe('agent generate test-spec NUTs', function () {
     const outputFile = join(session.project.dir, 'specs', genUniqueString('testSpec_%s.yaml'));
 
     execCmd(`agent generate test-spec --from-definition ${invalidFile} --output-file ${outputFile} --force-overwrite`, {
-      ensureExitCode: 2,
+      ensureExitCode: 'nonZero',
     });
   });
 });

--- a/test/nuts/agent.generate.test-spec.nut.ts
+++ b/test/nuts/agent.generate.test-spec.nut.ts
@@ -58,7 +58,7 @@ describe('agent generate test-spec NUTs', function () {
     const outputFile = join(session.project.dir, 'specs', genUniqueString('testSpec_%s.yaml'));
 
     execCmd(`agent generate test-spec --from-definition ${invalidFile} --output-file ${outputFile} --force-overwrite`, {
-      ensureExitCode: 1,
+      ensureExitCode: 2,
     });
   });
 
@@ -75,7 +75,7 @@ describe('agent generate test-spec NUTs', function () {
     const outputFile = join(session.project.dir, 'specs', genUniqueString('testSpec_%s.yaml'));
 
     execCmd(`agent generate test-spec --from-definition ${invalidFile} --output-file ${outputFile} --force-overwrite`, {
-      ensureExitCode: 1,
+      ensureExitCode: 2,
     });
   });
 });

--- a/test/nuts/agent.test.create.nut.ts
+++ b/test/nuts/agent.test.create.nut.ts
@@ -58,14 +58,14 @@ describe('agent test create', function () {
     const normalizedInvalidSpecPath = normalize(invalidSpecPath).replace(/\\/g, '/');
     execCmd<AgentTestCreateResult>(
       `agent test create --api-name "${testApiName}" --spec "${normalizedInvalidSpecPath}" --target-org ${getUsername()} --preview --json`,
-      { ensureExitCode: 1 }
+      { ensureExitCode: 2 }
     );
   });
 
   it('should fail when required flags are missing in JSON mode', async () => {
     // Missing --api-name
     execCmd<AgentTestCreateResult>(`agent test create --target-org ${getUsername()} --json`, {
-      ensureExitCode: 1,
+      ensureExitCode: 2,
     });
 
     // Missing --spec
@@ -73,7 +73,7 @@ describe('agent test create', function () {
     execCmd<AgentTestCreateResult>(
       `agent test create --api-name "${testApiName}" --target-org ${getUsername()} --json`,
       {
-        ensureExitCode: 1,
+        ensureExitCode: 2,
       }
     );
   });

--- a/test/nuts/agent.test.create.nut.ts
+++ b/test/nuts/agent.test.create.nut.ts
@@ -58,14 +58,14 @@ describe('agent test create', function () {
     const normalizedInvalidSpecPath = normalize(invalidSpecPath).replace(/\\/g, '/');
     execCmd<AgentTestCreateResult>(
       `agent test create --api-name "${testApiName}" --spec "${normalizedInvalidSpecPath}" --target-org ${getUsername()} --preview --json`,
-      { ensureExitCode: 2 }
+      { ensureExitCode: 'nonZero' }
     );
   });
 
   it('should fail when required flags are missing in JSON mode', async () => {
     // Missing --api-name
     execCmd<AgentTestCreateResult>(`agent test create --target-org ${getUsername()} --json`, {
-      ensureExitCode: 2,
+      ensureExitCode: 'nonZero',
     });
 
     // Missing --spec
@@ -73,7 +73,7 @@ describe('agent test create', function () {
     execCmd<AgentTestCreateResult>(
       `agent test create --api-name "${testApiName}" --target-org ${getUsername()} --json`,
       {
-        ensureExitCode: 2,
+        ensureExitCode: 'nonZero',
       }
     );
   });


### PR DESCRIPTION
Six NUT cases asserted ensureExitCode: 1 but the commands fail at oclif flag-parse time (Flags.file({ exists: true }), parse callbacks that throw, validate callbacks, and missing required flags), which exits with code 2. Update the assertions to match.

@W-22403352@
