### PR TITLE
fix: use 'nonZero' exit code expectation for invalid --since @W-22435573

### DIFF
--- a/test/nuts/z4.agent.trace.list.nut.ts
+++ b/test/nuts/z4.agent.trace.list.nut.ts
@@ -109,7 +109,7 @@ describe('agent trace list', function () {
 
   it('rejects an invalid --since value', () => {
     execCmd('agent trace list --since not-a-date --json', {
-      ensureExitCode: 1,
+      ensureExitCode: 'nonZero',
       cwd: session.project.dir,
     });
   });


### PR DESCRIPTION
## Summary
- Update the "rejects an invalid --since value" NUT in `test/nuts/z4.agent.trace.list.nut.ts` to use `ensureExitCode: 'nonZero'` instead of `1`, so the test does not depend on a specific non-zero exit code.

@W-22435573@

## Test plan
- [ ] CI runs `z4.agent.trace.list.nut.ts` and the `rejects an invalid --since value` test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)