### PR TITLE
W-22456723: revert run-eval command to beta state

### DIFF
--- a/src/commands/agent/test/run-eval.ts
+++ b/src/commands/agent/test/run-eval.ts
@@ -71,7 +71,6 @@ export default class AgentTestRunEval extends SfCommand<RunEvalResult> {
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
   public static state = 'beta';
-  public static readonly hidden = true;
 
   public static readonly envVariablesSection = toHelpSection(
     'ENVIRONMENT VARIABLES',

--- a/src/commands/agent/test/run-eval.ts
+++ b/src/commands/agent/test/run-eval.ts
@@ -70,6 +70,8 @@ export default class AgentTestRunEval extends SfCommand<RunEvalResult> {
   public static readonly summary = messages.getMessage('summary');
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
+  public static state = 'beta';
+  public static readonly hidden = true;
 
   public static readonly envVariablesSection = toHelpSection(
     'ENVIRONMENT VARIABLES',

--- a/test/commands/agent/test/run-eval.test.ts
+++ b/test/commands/agent/test/run-eval.test.ts
@@ -141,9 +141,8 @@ describe('agent test run-eval', () => {
   // ─── State ─────────────────────────────────────────────────────────────────
 
   describe('command metadata', () => {
-    it('is in beta and hidden state', () => {
+    it('is in beta state', () => {
       expect(AgentTestRunEval.state).to.equal('beta');
-      expect(AgentTestRunEval.hidden).to.equal(true);
     });
   });
 

--- a/test/commands/agent/test/run-eval.test.ts
+++ b/test/commands/agent/test/run-eval.test.ts
@@ -141,9 +141,9 @@ describe('agent test run-eval', () => {
   // ─── State ─────────────────────────────────────────────────────────────────
 
   describe('command metadata', () => {
-    it('is not in beta or hidden state', () => {
-      expect(AgentTestRunEval.state).to.not.equal('beta');
-      expect(AgentTestRunEval.hidden).to.not.equal(true);
+    it('is in beta and hidden state', () => {
+      expect(AgentTestRunEval.state).to.equal('beta');
+      expect(AgentTestRunEval.hidden).to.equal(true);
     });
   });
 


### PR DESCRIPTION
## Summary

@W-22456723@

Reverts the `agent test run-eval` command back to beta/hidden state while keeping all the refactoring improvements from PR #413.

This change:
- Sets `state = 'beta'` on the command class
- Updates the test assertion to verify beta state

All the logic improvements from PR #413 remain intact (delegation to `@salesforce/agents` library, improved test coverage, etc.). Only the GA promotion is being reverted.

## Test plan

- [x] `yarn compile` passes
- [x] `yarn test` passes including updated `test/commands/agent/test/run-eval.test.ts`
- [ ] `sf agent test run-eval --help`
- [ ] Command shows `(beta)` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)