### PR TITLE
W-22816781: fix: multi-file, list filter, retriever swap, oclif fix @W-22816781@

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -41,7 +41,7 @@
     "command": "agent:adl:file:add",
     "flagAliases": [],
     "flagChars": ["f", "i", "o"],
-    "flags": ["api-version", "file", "flags-dir", "json", "library-id", "target-org"],
+    "flags": ["api-version", "flags-dir", "json", "library-id", "path", "target-org"],
     "plugin": "@salesforce/plugin-agent"
   },
   {
@@ -73,7 +73,7 @@
     "command": "agent:adl:list",
     "flagAliases": [],
     "flagChars": ["o"],
-    "flags": ["api-version", "flags-dir", "json", "target-org"],
+    "flags": ["api-version", "flags-dir", "json", "source-type", "target-org"],
     "plugin": "@salesforce/plugin-agent"
   },
   {
@@ -98,6 +98,7 @@
       "library-id",
       "name",
       "restrict-to-public-articles",
+      "retriever-id",
       "target-org"
     ],
     "plugin": "@salesforce/plugin-agent"

--- a/messages/agent.adl.file.add.md
+++ b/messages/agent.adl.file.add.md
@@ -12,15 +12,19 @@ Constraints: at least 1 file required, no duplicate file names in a batch, maxim
 
 - Add a file to an existing library:
 
-  <%= config.bin %> <%= command.id %> --library-id 1JDSG000007IbWX4A0 --file ./docs/new-guide.pdf --target-org myOrg
+  <%= config.bin %> <%= command.id %> -i 1JDSG000007IbWX4A0 --path ./docs/new-guide.pdf --target-org myOrg
+
+- Add multiple files:
+
+  <%= config.bin %> <%= command.id %> -i 1JDSG000007IbWX4A0 --path ./docs/guide.pdf --path ./docs/faq.txt --target-org myOrg
 
 # flags.library-id.summary
 
 Agentforce Data Library ID (18-char Salesforce ID with prefix 1JD).
 
-# flags.file.summary
+# flags.path.summary
 
-Path to the file to add to the library.
+Path to file(s) to add. Specify multiple times for batch upload.
 
 # error.addFailed
 

--- a/messages/agent.adl.list.md
+++ b/messages/agent.adl.list.md
@@ -16,6 +16,10 @@ Returns all data libraries in the target org, including their source type, statu
 
   <%= config.bin %> <%= command.id %> --target-org myOrg --json
 
+# flags.source-type.summary
+
+Filter by source type: sfdrive, knowledge, or retriever.
+
 # error.listFailed
 
 Failed to list data libraries: %s

--- a/messages/agent.adl.update.md
+++ b/messages/agent.adl.update.md
@@ -44,6 +44,10 @@ Comma-separated list of content fields for KNOWLEDGE libraries (triggers re-inde
 
 Restrict to public Knowledge articles only (KNOWLEDGE libraries, triggers re-indexing).
 
+# flags.retriever-id.summary
+
+Swap the retriever for a RETRIEVER library (must be an active Custom Retriever ID).
+
 # error.updateFailed
 
 Failed to update data library: %s

--- a/schemas/agent-adl-file-add.json
+++ b/schemas/agent-adl-file-add.json
@@ -14,11 +14,17 @@
         "fileName": {
           "type": "string"
         },
+        "fileNames": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "libraryId": {
           "type": "string"
         }
       },
-      "required": ["success", "fileName", "libraryId"],
+      "required": ["success", "fileName", "fileNames", "libraryId"],
       "additionalProperties": false
     }
   }

--- a/src/commands/agent/adl/file/add.ts
+++ b/src/commands/agent/adl/file/add.ts
@@ -37,11 +37,12 @@ export default class AgentAdlFileAdd extends SfCommand<AgentAdlFileAddResult> {
       char: 'i',
       required: true,
     }),
-    file: Flags.file({
-      summary: messages.getMessage('flags.file.summary'),
+    path: Flags.file({
+      summary: messages.getMessage('flags.path.summary'),
       char: 'f',
       required: true,
       exists: true,
+      multiple: true,
     }),
   };
 
@@ -49,11 +50,11 @@ export default class AgentAdlFileAdd extends SfCommand<AgentAdlFileAddResult> {
     const { flags } = await this.parse(AgentAdlFileAdd);
     const connection = flags['target-org'].getConnection(flags['api-version']);
     const libraryId = flags['library-id'];
-    const filePath = flags.file;
+    const filePaths = flags.path;
 
     let result: FileAddResult;
     try {
-      result = await AgentDataLibrary.addFile(connection, libraryId, filePath);
+      result = await AgentDataLibrary.addFile(connection, libraryId, filePaths);
     } catch (error) {
       const wrapped = SfError.wrap(error);
       throw new SfError(messages.getMessage('error.addFailed', [wrapped.message]), 'AddFailed', [], 4, wrapped);

--- a/src/commands/agent/adl/file/add.ts
+++ b/src/commands/agent/adl/file/add.ts
@@ -60,7 +60,10 @@ export default class AgentAdlFileAdd extends SfCommand<AgentAdlFileAddResult> {
       throw new SfError(messages.getMessage('error.addFailed', [wrapped.message]), 'AddFailed', [], 4, wrapped);
     }
 
-    this.log(`File added to library ${libraryId}.`);
+    this.log(`Added ${result.fileNames.length} file(s) to library ${libraryId}:`);
+    for (const name of result.fileNames) {
+      this.log(`  ${name}`);
+    }
     return result;
   }
 }

--- a/src/commands/agent/adl/file/list.ts
+++ b/src/commands/agent/adl/file/list.ts
@@ -51,7 +51,20 @@ export default class AgentAdlFileList extends SfCommand<AgentAdlFileListResult> 
       throw new SfError(messages.getMessage('error.listFailed', [wrapped.message]), 'ListFailed', [], 4, wrapped);
     }
 
-    this.log(`Found ${files.length} file(s).`);
+    if (!this.jsonEnabled() && files.length > 0) {
+      this.table({
+        data: files,
+        columns: [
+          { key: 'fileName', name: 'File Name' },
+          { key: 'fileSize', name: 'Size (bytes)' },
+          { key: 'fileId', name: 'File ID' },
+          { key: 'createdDate', name: 'Created' },
+        ],
+      });
+    } else if (!this.jsonEnabled()) {
+      this.log('No files found.');
+    }
+
     return { files };
   }
 }

--- a/src/commands/agent/adl/get.ts
+++ b/src/commands/agent/adl/get.ts
@@ -51,7 +51,22 @@ export default class AgentAdlGet extends SfCommand<AgentAdlGetResult> {
       throw new SfError(messages.getMessage('error.getFailed', [wrapped.message]), 'GetFailed', [], 4, wrapped);
     }
 
-    this.log(`Library: ${result.masterLabel} (${result.libraryId}) — ${result.sourceType} — ${String(result.status)}`);
+    if (!this.jsonEnabled()) {
+      this.log(`Library: ${result.masterLabel} (${result.libraryId})`);
+      this.log(`  Source Type: ${result.sourceType}`);
+      this.log(`  Status: ${String(result.status)}`);
+      if (result.retrieverId) {
+        this.log(`  Retriever ID: ${result.retrieverId}`);
+        this.log(`  rag_feature_config_id: ARFPC_${result.libraryId}`);
+      }
+      if (result.description) {
+        this.log(`  Description: ${result.description}`);
+      }
+      const fileCount = result.groundingSource?.groundingFileRefs?.length;
+      if (fileCount) {
+        this.log(`  Files: ${String(fileCount)}`);
+      }
+    }
     return result;
   }
 }

--- a/src/commands/agent/adl/list.ts
+++ b/src/commands/agent/adl/list.ts
@@ -32,6 +32,10 @@ export default class AgentAdlList extends SfCommand<AgentAdlListResult> {
   public static readonly flags = {
     'target-org': Flags.requiredOrg(),
     'api-version': Flags.orgApiVersion(),
+    'source-type': Flags.option({
+      summary: messages.getMessage('flags.source-type.summary'),
+      options: ['sfdrive', 'knowledge', 'retriever'] as const,
+    })(),
   };
 
   public async run(): Promise<AgentAdlListResult> {
@@ -40,7 +44,9 @@ export default class AgentAdlList extends SfCommand<AgentAdlListResult> {
 
     let result: { libraries: DataLibrarySummary[] };
     try {
-      result = await AgentDataLibrary.list(connection);
+      result = await AgentDataLibrary.list(connection, {
+        sourceType: flags['source-type'],
+      });
     } catch (error) {
       const wrapped = SfError.wrap(error);
       throw new SfError(messages.getMessage('error.listFailed', [wrapped.message]), 'ListFailed', [], 4, wrapped);

--- a/src/commands/agent/adl/update.ts
+++ b/src/commands/agent/adl/update.ts
@@ -89,6 +89,14 @@ export default class AgentAdlUpdate extends SfCommand<AgentAdlUpdateResult> {
     }
 
     if (flags['retriever-id']) {
+      if (hasKnowledgeFlags) {
+        throw new SfError(
+          'Cannot combine --retriever-id with --content-fields or --restrict-to-public-articles.',
+          'ConflictingFlags',
+          [],
+          1
+        );
+      }
       input.groundingSource = {
         sourceType: 'RETRIEVER',
         retrieverId: flags['retriever-id'],

--- a/src/commands/agent/adl/update.ts
+++ b/src/commands/agent/adl/update.ts
@@ -51,6 +51,9 @@ export default class AgentAdlUpdate extends SfCommand<AgentAdlUpdateResult> {
       summary: messages.getMessage('flags.restrict-to-public-articles.summary'),
       allowNo: true,
     }),
+    'retriever-id': Flags.string({
+      summary: messages.getMessage('flags.retriever-id.summary'),
+    }),
   };
 
   public async run(): Promise<AgentAdlUpdateResult> {
@@ -83,6 +86,13 @@ export default class AgentAdlUpdate extends SfCommand<AgentAdlUpdateResult> {
           knowledgeConfig,
         };
       }
+    }
+
+    if (flags['retriever-id']) {
+      input.groundingSource = {
+        sourceType: 'RETRIEVER',
+        retrieverId: flags['retriever-id'],
+      };
     }
 
     let result: DataLibraryDetail;

--- a/src/commands/agent/adl/upload.ts
+++ b/src/commands/agent/adl/upload.ts
@@ -42,6 +42,7 @@ export default class AgentAdlUpload extends SfCommand<AgentAdlUploadResult> {
       char: 'f',
       required: true,
       exists: true,
+      multiple: true,
     }),
     // eslint-disable-next-line sf-plugin/flag-min-max-default
     wait: Flags.duration({
@@ -56,11 +57,11 @@ export default class AgentAdlUpload extends SfCommand<AgentAdlUploadResult> {
     const { flags } = await this.parse(AgentAdlUpload);
     const connection = flags['target-org'].getConnection(flags['api-version']);
     const libraryId = flags['library-id'];
-    const filePath = flags.file;
+    const filePaths = flags.file;
 
     let result: UploadResult;
     try {
-      result = await AgentDataLibrary.upload(connection, libraryId, filePath, {
+      result = await AgentDataLibrary.upload(connection, libraryId, filePaths, {
         waitMinutes: flags.wait?.minutes,
       });
     } catch (error) {

--- a/src/commands/agent/adl/upload.ts
+++ b/src/commands/agent/adl/upload.ts
@@ -58,9 +58,13 @@ export default class AgentAdlUpload extends SfCommand<AgentAdlUploadResult> {
     const connection = flags['target-org'].getConnection(flags['api-version']);
     const libraryId = flags['library-id'];
     const filePaths = flags.file;
+    const fileCount = filePaths.length;
+
+    this.log(`Uploading ${fileCount} file(s) to library ${libraryId}...`);
 
     let result: UploadResult;
     try {
+      this.log('Checking upload readiness...');
       result = await AgentDataLibrary.upload(connection, libraryId, filePaths, {
         waitMinutes: flags.wait?.minutes,
       });
@@ -70,9 +74,12 @@ export default class AgentAdlUpload extends SfCommand<AgentAdlUploadResult> {
     }
 
     if (result.status === 'READY') {
-      this.log(`Library ready. retrieverId: ${String(result.retrieverId)}`);
+      this.log('Library ready.');
+      this.log(`  retrieverId: ${String(result.retrieverId)}`);
+      this.log(`  rag_feature_config_id: ${String(result.ragFeatureConfigId)}`);
     } else {
-      this.log('Indexing triggered. Use "sf agent adl get" to check readiness.');
+      this.log(`Upload complete — indexing ${fileCount} file(s).`);
+      this.log('Use "sf agent adl status" to check progress, or "sf agent adl get" for readiness.');
     }
 
     return result;

--- a/test/commands/agent/adl/list.test.ts
+++ b/test/commands/agent/adl/list.test.ts
@@ -52,6 +52,20 @@ describe('agent adl list', () => {
     expect(result.libraries).to.deep.equal(mockLibraries);
   });
 
+  it('should pass --source-type filter', async () => {
+    const testOrg = new MockTestOrgData();
+    await $$.stubAuths(testOrg);
+    let capturedUrl: string | undefined;
+    $$.fakeConnectionRequest = (request: { url?: string }) => {
+      capturedUrl = request.url;
+      return Promise.resolve({ libraries: [] });
+    };
+
+    await AgentAdlList.run(['--target-org', testOrg.username, '--source-type', 'knowledge']);
+
+    expect(capturedUrl).to.include('?sourceType=KNOWLEDGE');
+  });
+
   it('should throw ListFailed on API error', async () => {
     const testOrg = new MockTestOrgData();
     await $$.stubAuths(testOrg);

--- a/test/commands/agent/adl/update.test.ts
+++ b/test/commands/agent/adl/update.test.ts
@@ -147,6 +147,31 @@ describe('agent adl update', () => {
     expect(result.libraryId).to.equal('1JD000001');
   });
 
+  it('should pass retriever-id for RETRIEVER swap', async () => {
+    const mockResult = { libraryId: '1JD000001', masterLabel: 'Ret', developerName: 'Ret', status: 'READY' };
+    let capturedBody: string | undefined;
+
+    const testOrg = new MockTestOrgData();
+    await $$.stubAuths(testOrg);
+    $$.fakeConnectionRequest = (request: { method?: string; body?: string }) => {
+      if (request.method === 'PATCH') capturedBody = request.body;
+      return Promise.resolve(mockResult);
+    };
+
+    await AgentAdlUpdate.run([
+      '--target-org',
+      testOrg.username,
+      '--library-id',
+      '1JD000001',
+      '--retriever-id',
+      '1Cx000NEW',
+    ]);
+
+    const body = JSON.parse(capturedBody!);
+    expect(body.groundingSource.sourceType).to.equal('RETRIEVER');
+    expect(body.groundingSource.retrieverId).to.equal('1Cx000NEW');
+  });
+
   it('should throw UpdateFailed on API error', async () => {
     const testOrg = new MockTestOrgData();
     await $$.stubAuths(testOrg);

--- a/test/nuts/agent.adl.nut.ts
+++ b/test/nuts/agent.adl.nut.ts
@@ -104,11 +104,11 @@ describe('agent adl SFDRIVE NUTs', function () {
     expect(result.jsonOutput!.result.indexingStatus).to.have.property('status');
   });
 
-  it('should upload a file and wait for READY', function () {
+  it('should upload multiple files and wait for READY', function () {
     this.timeout(10 * 60 * 1000);
 
     const result = execCmd<{ libraryId: string; status: string; retrieverId?: string }>(
-      `agent adl upload --target-org ${targetOrg} --library-id ${libraryId} --file ${testFile} --wait 10 --json`,
+      `agent adl upload --target-org ${targetOrg} --library-id ${libraryId} --file ${testFile} --file ${testFile2} --wait 10 --json`,
       { ensureExitCode: 0 }
     );
 
@@ -130,7 +130,21 @@ describe('agent adl SFDRIVE NUTs', function () {
     this.timeout(3 * 60 * 1000);
 
     const result = execCmd<{ success: boolean; fileName: string }>(
-      `agent adl file add --target-org ${targetOrg} --library-id ${libraryId} --file ${testFile2} --json`,
+      `agent adl file add -i ${libraryId} --path ${testFile2} --target-org ${targetOrg} --json`,
+      { ensureExitCode: 0 }
+    );
+
+    expect(result.jsonOutput!.result.success).to.be.true;
+  });
+
+  it('should add multiple files in batch', function () {
+    this.timeout(3 * 60 * 1000);
+
+    const file3 = join(tmpdir(), 'adl-nut-test3.txt');
+    writeFileSync(file3, 'Third NUT test file.');
+
+    const result = execCmd<{ success: boolean; fileName: string }>(
+      `agent adl file add -i ${libraryId} --path ${testFile2} --path ${file3} --target-org ${targetOrg} --json`,
       { ensureExitCode: 0 }
     );
 
@@ -139,11 +153,22 @@ describe('agent adl SFDRIVE NUTs', function () {
 
   it('should list files in the library', () => {
     const result = execCmd<{ files: Array<{ fileId: string; fileName: string }> }>(
-      `agent adl file list --target-org ${targetOrg} --library-id ${libraryId} --json`,
+      `agent adl file list -i ${libraryId} -o ${targetOrg} --json`,
       { ensureExitCode: 0 }
     );
 
     expect(result.jsonOutput!.result.files.length).to.be.greaterThan(0);
+  });
+
+  it('should list with --source-type filter', () => {
+    const result = execCmd<{ libraries: Array<{ sourceType: string }> }>(
+      `agent adl list --target-org ${targetOrg} --source-type sfdrive --json`,
+      { ensureExitCode: 0 }
+    );
+
+    for (const lib of result.jsonOutput!.result.libraries) {
+      expect(lib.sourceType).to.equal('SFDRIVE');
+    }
   });
 
   it('should delete the library (best-effort cleanup)', () => {
@@ -286,6 +311,15 @@ describe('agent adl RETRIEVER NUTs', function () {
     );
 
     expect(result.jsonOutput!.result.masterLabel).to.equal('NUT_Ret_Updated');
+  });
+
+  it('should swap retrieverId via --retriever-id flag', () => {
+    const result = execCmd<{ libraryId: string; retrieverId: string }>(
+      `agent adl update --target-org ${targetOrg} --library-id ${libraryId} --retriever-id ${retrieverId} --json`,
+      { ensureExitCode: 0 }
+    );
+
+    expect(result.jsonOutput!.result.retrieverId).to.equal(retrieverId);
   });
 
   it('should delete Retriever library', () => {


### PR DESCRIPTION
  fix: multi-file, list filter, retriever swap, oclif fix @W-22816781@

  - upload: --file supports multiple values (batch upload)
  - file add: renamed --file to --path (fixes oclif topic/flag collision), supports multiple
  - list: adds --source-type filter (sfdrive|knowledge|retriever)
  - update: adds --retriever-id flag for swapping retrievers on RETRIEVER libraries
  - Unit tests: list filter, retriever-id swap (27 total)
  - NUT tests: multi-file upload, multi-file add, list filter, retriever swap
  
### What does this PR do?
  Addresses feature gaps and oclif parser bug for ADL CLI commands:
  - upload: --file supports multiple values for batch upload
  - update: adds --retriever-id flag for swapping retrievers on RETRIEVER libraries
  - Includes unit tests and NUT tests for all new functionality
  
  Depends on: forcedotcom/agents#298
  
### What issues does this PR fix or reference?
@W-22816781@
