### PR TITLE
chore: bump @salesforce/agents to 1.8.1 @W-22816781@

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@inquirer/prompts": "^7.10.1",
     "@oclif/core": "^4",
     "@oclif/multi-stage-output": "^0.8.36",
-    "@salesforce/agents": "^1.8.0",
+    "@salesforce/agents": "^1.8.1",
     "@salesforce/core": "^8.28.3",
     "@salesforce/kit": "^3.2.6",
     "@salesforce/sf-plugins-core": "^12.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1411,10 +1411,10 @@
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
-"@salesforce/agents@^1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@salesforce/agents/-/agents-1.8.0.tgz#a96eacc28fab195fa82f940e5fafdb252f774501"
-  integrity sha512-D65MUnEnAsuFcXwBW48HsFdFsdqJx+VWuzsyKRkc7d0XCCwFbkkiyydRoqi1tCHLx+4rqsPMnImezahyW5inIA==
+"@salesforce/agents@^1.8.1":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/agents/-/agents-1.8.1.tgz#3739755f7356c36b8b88f861a13c0f72797d57ba"
+  integrity sha512-DyybLIzO/eo1xLxus02e9W1e/xY6Jwet531qztaUfMF/YCW+Mbonn6WJFeN2orWJcSop5TOz1C5tkDOrNAQsDg==
   dependencies:
     "@salesforce/core" "^8.31.0"
     "@salesforce/kit" "^3.2.6"


### PR DESCRIPTION
chore: bump @salesforce/agents to 1.8.1 @W-22816781@

### What does this PR do?
Bumps @salesforce/agents to 1.8.1 which includes multi-file batch support, sourceType list filter, and retriever swap (from forcedotcom/agents#298).

### What issues does this PR fix or reference?
@W-22816781@