### PR TITLE
@W-22860636 feat: add sf agent mcp commands for MCP server management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1001,16 +1001,18 @@ Replace the asset set of an MCP server in the API Catalog.
 
 ```
 USAGE
-  $ sf agent mcp asset replace -o <value> -i <value> --assets-file <value> [--json] [--flags-dir <value>] [--api-version
-    <value>]
+  $ sf agent mcp asset replace -o <value> -i <value> [--json] [--flags-dir <value>] [--api-version <value>] [--assets <value>
+    | --assets-file <value>]
 
 FLAGS
   -i, --mcp-server-id=<value>  (required) ID of the MCP server whose assets you want to replace.
   -o, --target-org=<value>     (required) Username or alias of the target org. Not required if the `target-org`
                                configuration variable is already set.
       --api-version=<value>    Override the api version used for api requests made by this command
-      --assets-file=<value>    (required) Path to a JSON file containing an array of asset items or an object of the
-                               form { "assets": [...] }.
+      --assets=<value>         The desired asset allowlist as a JSON string (or "-" to read from stdin). Mutually
+                               exclusive with --assets-file.
+      --assets-file=<value>    Path to a JSON file containing the desired asset allowlist. Mutually exclusive with
+                               --assets.
 
 GLOBAL FLAGS
   --flags-dir=<value>  Import flag values from a directory.
@@ -1019,20 +1021,25 @@ GLOBAL FLAGS
 DESCRIPTION
   Replace the asset set of an MCP server in the API Catalog.
 
-  Replaces the full set of assets (tools, prompts, resources) for an MCP server with the asset items supplied in a JSON
-  file. The file must contain either a JSON array of asset items or an object of the form `{ "assets": [...] }`. Each
-  asset item may include `id`, `name`, `label`, `description`, `active`, and `kind`. Existing assets not present in the
-  supplied set may be removed, so provide the complete desired asset set.
+  Replaces the full set of assets (tools, prompts, resources) for an MCP server with the asset items you supply. Provide
+  the assets either inline with `--assets` (a JSON string, or `-` to read from stdin) or from a file with
+  `--assets-file`. The JSON must be either an array of asset items or an object of the form `{ "assets": [...] }`. Each
+  asset item may include `id`, `name`, `label`, `description`, `active`, and `kind`. This is a full replacement:
+  existing assets not present in the supplied set are removed, so provide the complete desired asset set (read the
+  current set first with `agent mcp asset list` or `agent mcp fetch`).
 
 EXAMPLES
-  Replace the assets of an MCP server using a JSON file that contains an array of asset items:
+  Replace the assets inline with a JSON string:
+
+    $ sf agent mcp asset replace --mcp-server-id 0XSxx0000000001 --assets \
+      '{"assets":[{"name":"McpTool__add","active":true}]}' --target-org myOrg
+
+  Replace the assets from a JSON file:
 
     $ sf agent mcp asset replace --mcp-server-id 0XSxx0000000001 --assets-file ./assets.json --target-org myOrg
 
-  Replace the assets and output the result as JSON:
-
-    $ sf agent mcp asset replace --mcp-server-id 0XSxx0000000001 --assets-file ./assets.json --target-org myOrg \
-      --json
+  Pipe the assets from stdin:
+  cat assets.json | sf agent mcp asset replace --mcp-server-id 0XSxx0000000001 --assets - --target-org myOrg
 ```
 
 _See code: [src/commands/agent/mcp/asset/replace.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/mcp/asset/replace.ts)_

--- a/README.md
+++ b/README.md
@@ -58,40 +58,47 @@ sf plugins
 ## Commands
 
 <!-- commands -->
-
-- [`sf agent activate`](#sf-agent-activate)
-- [`sf agent adl create`](#sf-agent-adl-create)
-- [`sf agent adl delete`](#sf-agent-adl-delete)
-- [`sf agent adl file add`](#sf-agent-adl-file-add)
-- [`sf agent adl file delete`](#sf-agent-adl-file-delete)
-- [`sf agent adl file list`](#sf-agent-adl-file-list)
-- [`sf agent adl get`](#sf-agent-adl-get)
-- [`sf agent adl list`](#sf-agent-adl-list)
-- [`sf agent adl status`](#sf-agent-adl-status)
-- [`sf agent adl update`](#sf-agent-adl-update)
-- [`sf agent adl upload`](#sf-agent-adl-upload)
-- [`sf agent create`](#sf-agent-create)
-- [`sf agent deactivate`](#sf-agent-deactivate)
-- [`sf agent generate agent-spec`](#sf-agent-generate-agent-spec)
-- [`sf agent generate authoring-bundle`](#sf-agent-generate-authoring-bundle)
-- [`sf agent generate template`](#sf-agent-generate-template)
-- [`sf agent generate test-spec`](#sf-agent-generate-test-spec)
-- [`sf agent preview`](#sf-agent-preview)
-- [`sf agent preview end`](#sf-agent-preview-end)
-- [`sf agent preview send`](#sf-agent-preview-send)
-- [`sf agent preview sessions`](#sf-agent-preview-sessions)
-- [`sf agent preview start`](#sf-agent-preview-start)
-- [`sf agent publish authoring-bundle`](#sf-agent-publish-authoring-bundle)
-- [`sf agent test create`](#sf-agent-test-create)
-- [`sf agent test list`](#sf-agent-test-list)
-- [`sf agent test results`](#sf-agent-test-results)
-- [`sf agent test resume`](#sf-agent-test-resume)
-- [`sf agent test run`](#sf-agent-test-run)
-- [`sf agent test run-eval`](#sf-agent-test-run-eval)
-- [`sf agent trace delete`](#sf-agent-trace-delete)
-- [`sf agent trace list`](#sf-agent-trace-list)
-- [`sf agent trace read`](#sf-agent-trace-read)
-- [`sf agent validate authoring-bundle`](#sf-agent-validate-authoring-bundle)
+* [`sf agent activate`](#sf-agent-activate)
+* [`sf agent adl create`](#sf-agent-adl-create)
+* [`sf agent adl delete`](#sf-agent-adl-delete)
+* [`sf agent adl file add`](#sf-agent-adl-file-add)
+* [`sf agent adl file delete`](#sf-agent-adl-file-delete)
+* [`sf agent adl file list`](#sf-agent-adl-file-list)
+* [`sf agent adl get`](#sf-agent-adl-get)
+* [`sf agent adl list`](#sf-agent-adl-list)
+* [`sf agent adl status`](#sf-agent-adl-status)
+* [`sf agent adl update`](#sf-agent-adl-update)
+* [`sf agent adl upload`](#sf-agent-adl-upload)
+* [`sf agent create`](#sf-agent-create)
+* [`sf agent deactivate`](#sf-agent-deactivate)
+* [`sf agent generate agent-spec`](#sf-agent-generate-agent-spec)
+* [`sf agent generate authoring-bundle`](#sf-agent-generate-authoring-bundle)
+* [`sf agent generate template`](#sf-agent-generate-template)
+* [`sf agent generate test-spec`](#sf-agent-generate-test-spec)
+* [`sf agent mcp asset list`](#sf-agent-mcp-asset-list)
+* [`sf agent mcp asset replace`](#sf-agent-mcp-asset-replace)
+* [`sf agent mcp create`](#sf-agent-mcp-create)
+* [`sf agent mcp delete`](#sf-agent-mcp-delete)
+* [`sf agent mcp fetch`](#sf-agent-mcp-fetch)
+* [`sf agent mcp get`](#sf-agent-mcp-get)
+* [`sf agent mcp list`](#sf-agent-mcp-list)
+* [`sf agent mcp update`](#sf-agent-mcp-update)
+* [`sf agent preview`](#sf-agent-preview)
+* [`sf agent preview end`](#sf-agent-preview-end)
+* [`sf agent preview send`](#sf-agent-preview-send)
+* [`sf agent preview sessions`](#sf-agent-preview-sessions)
+* [`sf agent preview start`](#sf-agent-preview-start)
+* [`sf agent publish authoring-bundle`](#sf-agent-publish-authoring-bundle)
+* [`sf agent test create`](#sf-agent-test-create)
+* [`sf agent test list`](#sf-agent-test-list)
+* [`sf agent test results`](#sf-agent-test-results)
+* [`sf agent test resume`](#sf-agent-test-resume)
+* [`sf agent test run`](#sf-agent-test-run)
+* [`sf agent test run-eval`](#sf-agent-test-run-eval)
+* [`sf agent trace delete`](#sf-agent-trace-delete)
+* [`sf agent trace list`](#sf-agent-trace-list)
+* [`sf agent trace read`](#sf-agent-trace-read)
+* [`sf agent validate authoring-bundle`](#sf-agent-validate-authoring-bundle)
 
 ## `sf agent activate`
 
@@ -140,7 +147,7 @@ EXAMPLES
     $ sf agent activate --api-name Resort_Manager --version 2 --target-org my-org
 ```
 
-_See code: [src/commands/agent/activate.ts](https://github.com/salesforcecli/plugin-agent/blob/1.42.1/src/commands/agent/activate.ts)_
+_See code: [src/commands/agent/activate.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/activate.ts)_
 
 ## `sf agent adl create`
 
@@ -198,7 +205,7 @@ EXAMPLES
       --source-type retriever --retriever-id 0ppXX0000000001
 ```
 
-_See code: [src/commands/agent/adl/create.ts](https://github.com/salesforcecli/plugin-agent/blob/1.42.1/src/commands/agent/adl/create.ts)_
+_See code: [src/commands/agent/adl/create.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/adl/create.ts)_
 
 ## `sf agent adl delete`
 
@@ -229,7 +236,7 @@ EXAMPLES
     $ sf agent adl delete --library-id 1JDSG000007IbWX4A0 --target-org myOrg
 ```
 
-_See code: [src/commands/agent/adl/delete.ts](https://github.com/salesforcecli/plugin-agent/blob/1.42.1/src/commands/agent/adl/delete.ts)_
+_See code: [src/commands/agent/adl/delete.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/adl/delete.ts)_
 
 ## `sf agent adl file add`
 
@@ -268,7 +275,7 @@ EXAMPLES
     $ sf agent adl file add -i 1JDSG000007IbWX4A0 --path ./docs/guide.pdf --path ./docs/faq.txt --target-org myOrg
 ```
 
-_See code: [src/commands/agent/adl/file/add.ts](https://github.com/salesforcecli/plugin-agent/blob/1.42.1/src/commands/agent/adl/file/add.ts)_
+_See code: [src/commands/agent/adl/file/add.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/adl/file/add.ts)_
 
 ## `sf agent adl file delete`
 
@@ -301,7 +308,7 @@ EXAMPLES
     $ sf agent adl file delete --library-id 1JDSG000007IbWX4A0 --file-id a1B2C3D4E5F6G7H8I9 --target-org myOrg
 ```
 
-_See code: [src/commands/agent/adl/file/delete.ts](https://github.com/salesforcecli/plugin-agent/blob/1.42.1/src/commands/agent/adl/file/delete.ts)_
+_See code: [src/commands/agent/adl/file/delete.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/adl/file/delete.ts)_
 
 ## `sf agent adl file list`
 
@@ -336,7 +343,7 @@ EXAMPLES
     $ sf agent adl file list --library-id 1JDSG000007IbWX4A0 --target-org myOrg --json
 ```
 
-_See code: [src/commands/agent/adl/file/list.ts](https://github.com/salesforcecli/plugin-agent/blob/1.42.1/src/commands/agent/adl/file/list.ts)_
+_See code: [src/commands/agent/adl/file/list.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/adl/file/list.ts)_
 
 ## `sf agent adl get`
 
@@ -367,7 +374,7 @@ EXAMPLES
     $ sf agent adl get --library-id 1JDSG000007IbWX4A0 --target-org myOrg
 ```
 
-_See code: [src/commands/agent/adl/get.ts](https://github.com/salesforcecli/plugin-agent/blob/1.42.1/src/commands/agent/adl/get.ts)_
+_See code: [src/commands/agent/adl/get.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/adl/get.ts)_
 
 ## `sf agent adl list`
 
@@ -404,7 +411,7 @@ EXAMPLES
     $ sf agent adl list --target-org myOrg --json
 ```
 
-_See code: [src/commands/agent/adl/list.ts](https://github.com/salesforcecli/plugin-agent/blob/1.42.1/src/commands/agent/adl/list.ts)_
+_See code: [src/commands/agent/adl/list.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/adl/list.ts)_
 
 ## `sf agent adl status`
 
@@ -436,7 +443,7 @@ EXAMPLES
     $ sf agent adl status --library-id 1JDSG000007IbWX4A0 --target-org myOrg
 ```
 
-_See code: [src/commands/agent/adl/status.ts](https://github.com/salesforcecli/plugin-agent/blob/1.42.1/src/commands/agent/adl/status.ts)_
+_See code: [src/commands/agent/adl/status.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/adl/status.ts)_
 
 ## `sf agent adl update`
 
@@ -488,7 +495,7 @@ EXAMPLES
     $ sf agent adl update --library-id 1JDSG000007IbWX4A0 --restrict-to-public-articles --target-org myOrg
 ```
 
-_See code: [src/commands/agent/adl/update.ts](https://github.com/salesforcecli/plugin-agent/blob/1.42.1/src/commands/agent/adl/update.ts)_
+_See code: [src/commands/agent/adl/update.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/adl/update.ts)_
 
 ## `sf agent adl upload`
 
@@ -531,7 +538,7 @@ EXAMPLES
     $ sf agent adl upload --library-id 1JDSG000007IbWX4A0 --file ./docs/guide.pdf --target-org myOrg
 ```
 
-_See code: [src/commands/agent/adl/upload.ts](https://github.com/salesforcecli/plugin-agent/blob/1.42.1/src/commands/agent/adl/upload.ts)_
+_See code: [src/commands/agent/adl/upload.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/adl/upload.ts)_
 
 ## `sf agent create`
 
@@ -598,7 +605,7 @@ EXAMPLES
     $ sf agent create --name "Resort Manager" --spec specs/resortManagerAgent.yaml --preview
 ```
 
-_See code: [src/commands/agent/create.ts](https://github.com/salesforcecli/plugin-agent/blob/1.42.1/src/commands/agent/create.ts)_
+_See code: [src/commands/agent/create.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/create.ts)_
 
 ## `sf agent deactivate`
 
@@ -639,7 +646,7 @@ EXAMPLES
     $ sf agent deactivate --api-name Resort_Manager --target-org my-org
 ```
 
-_See code: [src/commands/agent/deactivate.ts](https://github.com/salesforcecli/plugin-agent/blob/1.42.1/src/commands/agent/deactivate.ts)_
+_See code: [src/commands/agent/deactivate.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/deactivate.ts)_
 
 ## `sf agent generate agent-spec`
 
@@ -746,7 +753,7 @@ EXAMPLES
     $ sf agent generate agent-spec --tone formal --agent-user resortmanager@myorg.com
 ```
 
-_See code: [src/commands/agent/generate/agent-spec.ts](https://github.com/salesforcecli/plugin-agent/blob/1.42.1/src/commands/agent/generate/agent-spec.ts)_
+_See code: [src/commands/agent/generate/agent-spec.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/generate/agent-spec.ts)_
 
 ## `sf agent generate authoring-bundle`
 
@@ -823,7 +830,7 @@ EXAMPLES
       other-package-dir/main/default --target-org my-dev-org
 ```
 
-_See code: [src/commands/agent/generate/authoring-bundle.ts](https://github.com/salesforcecli/plugin-agent/blob/1.42.1/src/commands/agent/generate/authoring-bundle.ts)_
+_See code: [src/commands/agent/generate/authoring-bundle.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/generate/authoring-bundle.ts)_
 
 ## `sf agent generate template`
 
@@ -885,7 +892,7 @@ EXAMPLES
       my-package --source-org my-scratch-org
 ```
 
-_See code: [src/commands/agent/generate/template.ts](https://github.com/salesforcecli/plugin-agent/blob/1.42.1/src/commands/agent/generate/template.ts)_
+_See code: [src/commands/agent/generate/template.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/generate/template.ts)_
 
 ## `sf agent generate test-spec`
 
@@ -950,7 +957,337 @@ EXAMPLES
       force-app//main/default/aiEvaluationDefinitions/Resort_Manager_Tests.aiEvaluationDefinition-meta.xml
 ```
 
-_See code: [src/commands/agent/generate/test-spec.ts](https://github.com/salesforcecli/plugin-agent/blob/1.42.1/src/commands/agent/generate/test-spec.ts)_
+_See code: [src/commands/agent/generate/test-spec.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/generate/test-spec.ts)_
+
+## `sf agent mcp asset list`
+
+List the assets (tools, prompts, and resources) for an MCP server in the catalog.
+
+```
+USAGE
+  $ sf agent mcp asset list -o <value> -i <value> [--json] [--flags-dir <value>] [--api-version <value>]
+
+FLAGS
+  -i, --mcp-server-id=<value>  (required) The ID of the MCP server whose assets you want to list.
+  -o, --target-org=<value>     (required) Username or alias of the target org. Not required if the `target-org`
+                               configuration variable is already set.
+      --api-version=<value>    Override the api version used for api requests made by this command
+
+GLOBAL FLAGS
+  --flags-dir=<value>  Import flag values from a directory.
+  --json               Format output as json.
+
+DESCRIPTION
+  List the assets (tools, prompts, and resources) for an MCP server in the catalog.
+
+  Returns the assets discovered for the specified MCP server, including each asset's kind (MCP_TOOL, MCP_PROMPT, or
+  MCP_RESOURCE), whether it is active, and whether it is available as an agent action.
+
+EXAMPLES
+  List the assets for an MCP server in the default target org:
+
+    $ sf agent mcp asset list --target-org myOrg --mcp-server-id 0XSxx0000000001
+
+  List the assets for an MCP server and output as JSON:
+
+    $ sf agent mcp asset list --target-org myOrg --mcp-server-id 0XSxx0000000001 --json
+```
+
+_See code: [src/commands/agent/mcp/asset/list.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/mcp/asset/list.ts)_
+
+## `sf agent mcp asset replace`
+
+Replace the asset set of an MCP server in the API Catalog.
+
+```
+USAGE
+  $ sf agent mcp asset replace -o <value> -i <value> --assets-file <value> [--json] [--flags-dir <value>] [--api-version
+    <value>]
+
+FLAGS
+  -i, --mcp-server-id=<value>  (required) ID of the MCP server whose assets you want to replace.
+  -o, --target-org=<value>     (required) Username or alias of the target org. Not required if the `target-org`
+                               configuration variable is already set.
+      --api-version=<value>    Override the api version used for api requests made by this command
+      --assets-file=<value>    (required) Path to a JSON file containing an array of asset items or an object of the
+                               form { "assets": [...] }.
+
+GLOBAL FLAGS
+  --flags-dir=<value>  Import flag values from a directory.
+  --json               Format output as json.
+
+DESCRIPTION
+  Replace the asset set of an MCP server in the API Catalog.
+
+  Replaces the full set of assets (tools, prompts, resources) for an MCP server with the asset items supplied in a JSON
+  file. The file must contain either a JSON array of asset items or an object of the form `{ "assets": [...] }`. Each
+  asset item may include `id`, `name`, `label`, `description`, `active`, and `kind`. Existing assets not present in the
+  supplied set may be removed, so provide the complete desired asset set.
+
+EXAMPLES
+  Replace the assets of an MCP server using a JSON file that contains an array of asset items:
+
+    $ sf agent mcp asset replace --mcp-server-id 0XSxx0000000001 --assets-file ./assets.json --target-org myOrg
+
+  Replace the assets and output the result as JSON:
+
+    $ sf agent mcp asset replace --mcp-server-id 0XSxx0000000001 --assets-file ./assets.json --target-org myOrg \
+      --json
+```
+
+_See code: [src/commands/agent/mcp/asset/replace.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/mcp/asset/replace.ts)_
+
+## `sf agent mcp create`
+
+Create an MCP server in the API Catalog.
+
+```
+USAGE
+  $ sf agent mcp create -o <value> -n <value> --server-url <value> [--json] [--flags-dir <value>] [--api-version
+    <value>] [--label <value>] [--description <value>] [--auth-type OAUTH|NO_AUTH] [--identity-provider <value>]
+    [--client-id <value>] [--client-secret <value>] [--scope <value>]
+
+FLAGS
+  -n, --name=<value>               (required) Unique name of the MCP server.
+  -o, --target-org=<value>         (required) Username or alias of the target org. Not required if the `target-org`
+                                   configuration variable is already set.
+      --api-version=<value>        Override the api version used for api requests made by this command
+      --auth-type=<option>         [default: NO_AUTH] Authorization type to use when connecting to the MCP server.
+                                   <options: OAUTH|NO_AUTH>
+      --client-id=<value>          OAuth client ID. Required when auth-type is OAUTH.
+      --client-secret=<value>      OAuth client secret. Required when auth-type is OAUTH. Pass "-" to read it from stdin
+                                   (piped) and keep it out of shell history.
+      --description=<value>        Description of the MCP server.
+      --identity-provider=<value>  Identity provider to use for OAuth authorization. Required when auth-type is OAUTH.
+      --label=<value>              Human-readable label for the MCP server.
+      --scope=<value>              OAuth scope to request. Required when auth-type is OAUTH.
+      --server-url=<value>         (required) URL of the external MCP server.
+
+GLOBAL FLAGS
+  --flags-dir=<value>  Import flag values from a directory.
+  --json               Format output as json.
+
+DESCRIPTION
+  Create an MCP server in the API Catalog.
+
+  Registers an external Model Context Protocol (MCP) server with the API Catalog and discovers its assets (tools,
+  prompts, and resources). Provide the server URL and, when the server requires it, OAuth authorization details. When
+  the authorization type is OAUTH you must supply the identity provider, client ID, client secret, and scope.
+
+EXAMPLES
+  Create an MCP server with no authentication:
+
+    $ sf agent mcp create --name myServer --server-url https://mcp.example.com --target-org myOrg
+
+  Create an MCP server that uses OAuth authentication, piping the client secret from stdin to keep it out of shell history:
+  cat secret.txt | sf agent mcp create --name myServer --server-url https://mcp.example.com --auth-type OAUTH --identity-provider myIdp --client-id abc123 --client-secret - --scope "read write" --target-org myOrg
+```
+
+_See code: [src/commands/agent/mcp/create.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/mcp/create.ts)_
+
+## `sf agent mcp delete`
+
+Delete an MCP server from the API Catalog.
+
+```
+USAGE
+  $ sf agent mcp delete -o <value> -i <value> [--json] [--flags-dir <value>] [--api-version <value>] [--no-prompt]
+
+FLAGS
+  -i, --mcp-server-id=<value>  (required) ID of the MCP server to delete.
+  -o, --target-org=<value>     (required) Username or alias of the target org. Not required if the `target-org`
+                               configuration variable is already set.
+      --api-version=<value>    Override the api version used for api requests made by this command
+      --no-prompt              Skip the confirmation prompt and delete the MCP server immediately.
+
+GLOBAL FLAGS
+  --flags-dir=<value>  Import flag values from a directory.
+  --json               Format output as json.
+
+DESCRIPTION
+  Delete an MCP server from the API Catalog.
+
+  Permanently removes an MCP (Model Context Protocol) server registration from the API Catalog, identified by its ID. By
+  default you are prompted to confirm the deletion; pass --no-prompt to skip the confirmation (for example in scripts
+  and CI).
+
+EXAMPLES
+  Delete an MCP server, confirming interactively:
+
+    $ sf agent mcp delete --mcp-server-id 0XSxx0000000001 --target-org myOrg
+
+  Delete an MCP server without a confirmation prompt:
+
+    $ sf agent mcp delete --mcp-server-id 0XSxx0000000001 --target-org myOrg --no-prompt
+```
+
+_See code: [src/commands/agent/mcp/delete.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/mcp/delete.ts)_
+
+## `sf agent mcp fetch`
+
+Fetch the live assets (tools, prompts, resources) advertised by an MCP server.
+
+```
+USAGE
+  $ sf agent mcp fetch -o <value> -i <value> [--json] [--flags-dir <value>] [--api-version <value>]
+
+FLAGS
+  -i, --mcp-server-id=<value>  (required) ID of the MCP server to fetch assets from.
+  -o, --target-org=<value>     (required) Username or alias of the target org. Not required if the `target-org`
+                               configuration variable is already set.
+      --api-version=<value>    Override the api version used for api requests made by this command
+
+GLOBAL FLAGS
+  --flags-dir=<value>  Import flag values from a directory.
+  --json               Format output as json.
+
+DESCRIPTION
+  Fetch the live assets (tools, prompts, resources) advertised by an MCP server.
+
+  Performs a live fetch against the configured MCP server identified by its ID, returning the assets (MCP tools,
+  prompts, and resources) it currently advertises along with their status and activation state. Use this to refresh the
+  view of what an MCP server exposes before activating its assets as agent actions.
+
+EXAMPLES
+  Fetch the assets advertised by an MCP server in the default target org:
+
+    $ sf agent mcp fetch --target-org myOrg --mcp-server-id 0XSxx0000000001
+
+  Fetch MCP server assets and output as JSON:
+
+    $ sf agent mcp fetch --target-org myOrg --mcp-server-id 0XSxx0000000001 --json
+```
+
+_See code: [src/commands/agent/mcp/fetch.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/mcp/fetch.ts)_
+
+## `sf agent mcp get`
+
+Get a single MCP server registered in the API Catalog.
+
+```
+USAGE
+  $ sf agent mcp get -o <value> -i <value> [--json] [--flags-dir <value>] [--api-version <value>]
+
+FLAGS
+  -i, --mcp-server-id=<value>  (required) The identifier of the MCP server to retrieve.
+  -o, --target-org=<value>     (required) Username or alias of the target org. Not required if the `target-org`
+                               configuration variable is already set.
+      --api-version=<value>    Override the api version used for api requests made by this command
+
+GLOBAL FLAGS
+  --flags-dir=<value>  Import flag values from a directory.
+  --json               Format output as json.
+
+DESCRIPTION
+  Get a single MCP server registered in the API Catalog.
+
+  Retrieves the details of an MCP (Model Context Protocol) server by its identifier, including its name, label, type,
+  status, and server URL.
+
+EXAMPLES
+  Get an MCP server by id in the default target org:
+
+    $ sf agent mcp get --target-org myOrg --mcp-server-id 0Mx000000000001
+
+  Get an MCP server and output as JSON:
+
+    $ sf agent mcp get --target-org myOrg --mcp-server-id 0Mx000000000001 --json
+```
+
+_See code: [src/commands/agent/mcp/get.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/mcp/get.ts)_
+
+## `sf agent mcp list`
+
+List the MCP servers registered in the API Catalog.
+
+```
+USAGE
+  $ sf agent mcp list -o <value> [--json] [--flags-dir <value>] [--api-version <value>] [--label <value>] [--type
+    EXTERNAL] [--status ACTIVE|DISCONNECTED]
+
+FLAGS
+  -o, --target-org=<value>   (required) Username or alias of the target org. Not required if the `target-org`
+                             configuration variable is already set.
+      --api-version=<value>  Override the api version used for api requests made by this command
+      --label=<value>        Filter the MCP servers by label.
+      --status=<option>      Filter the MCP servers by connection status. Only ACTIVE and DISCONNECTED are supported as
+                             filters.
+                             <options: ACTIVE|DISCONNECTED>
+      --type=<option>        Filter the MCP servers by type.
+                             <options: EXTERNAL>
+
+GLOBAL FLAGS
+  --flags-dir=<value>  Import flag values from a directory.
+  --json               Format output as json.
+
+DESCRIPTION
+  List the MCP servers registered in the API Catalog.
+
+  Returns the Model Context Protocol (MCP) servers registered in the API Catalog, optionally filtered by label, type, or
+  status. Use this to discover which MCP servers are available and inspect their server URLs and current status.
+
+EXAMPLES
+  List all MCP servers in the default target org:
+
+    $ sf agent mcp list --target-org myOrg
+
+  List external MCP servers filtered by status and output as JSON:
+
+    $ sf agent mcp list --target-org myOrg --type EXTERNAL --status ACTIVE --json
+```
+
+_See code: [src/commands/agent/mcp/list.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/mcp/list.ts)_
+
+## `sf agent mcp update`
+
+Update an MCP server registered in the API Catalog.
+
+```
+USAGE
+  $ sf agent mcp update -o <value> -i <value> [--json] [--flags-dir <value>] [--api-version <value>] [--label <value>]
+    [--description <value>] [--server-url <value>] [--auth-type OAUTH|NO_AUTH] [--identity-provider <value>]
+    [--client-id <value>] [--client-secret <value>] [--scope <value>]
+
+FLAGS
+  -i, --mcp-server-id=<value>      (required) ID of the MCP server to update.
+  -o, --target-org=<value>         (required) Username or alias of the target org. Not required if the `target-org`
+                                   configuration variable is already set.
+      --api-version=<value>        Override the api version used for api requests made by this command
+      --auth-type=<option>         Authorization type to apply to the MCP server (OAUTH or NO_AUTH).
+                                   <options: OAUTH|NO_AUTH>
+      --client-id=<value>          OAuth client ID (required when --auth-type is OAUTH).
+      --client-secret=<value>      OAuth client secret (required when --auth-type is OAUTH). Pass "-" to read it from
+                                   stdin (piped) and keep it out of shell history.
+      --description=<value>        New description for the MCP server.
+      --identity-provider=<value>  Identity provider name for OAuth authorization (required when --auth-type is OAUTH).
+      --label=<value>              New display label for the MCP server.
+      --scope=<value>              OAuth scope (required when --auth-type is OAUTH).
+      --server-url=<value>         New endpoint URL of the MCP server.
+
+GLOBAL FLAGS
+  --flags-dir=<value>  Import flag values from a directory.
+  --json               Format output as json.
+
+DESCRIPTION
+  Update an MCP server registered in the API Catalog.
+
+  Updates an existing MCP server in the API Catalog. Only the fields you provide are changed; omitted fields are left
+  untouched. You can update the label, description, and server URL, and replace the authorization configuration. When
+  setting `--auth-type OAUTH`, you must also provide `--identity-provider`, `--client-id`, `--client-secret`, and
+  `--scope`. When setting `--auth-type NO_AUTH`, no authorization credentials are required. At least one updatable field
+  must be supplied.
+
+EXAMPLES
+  Update the label and description of an MCP server in the default target org:
+
+    $ sf agent mcp update --mcp-server-id 0XSxx0000000001 --label "Orders MCP" --description "Order tooling" \
+      --target-org myOrg
+
+  Update the server URL and switch the authorization to OAuth, piping the client secret from stdin and outputting as JSON:
+  cat secret.txt | sf agent mcp update --mcp-server-id 0XSxx0000000001 --server-url https://mcp.example.com --auth-type OAUTH --identity-provider MyIdp --client-id abc --client-secret - --scope "read write" --target-org myOrg --json
+```
+
+_See code: [src/commands/agent/mcp/update.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/mcp/update.ts)_
 
 ## `sf agent preview`
 
@@ -1023,7 +1360,7 @@ EXAMPLES
     $ sf agent preview --use-live-actions --apex-debug --output-dir transcripts/my-preview
 ```
 
-_See code: [src/commands/agent/preview.ts](https://github.com/salesforcecli/plugin-agent/blob/1.42.1/src/commands/agent/preview.ts)_
+_See code: [src/commands/agent/preview.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/preview.ts)_
 
 ## `sf agent preview end`
 
@@ -1095,7 +1432,7 @@ EXAMPLES
     $ sf agent preview end --all --target-org <target_org>
 ```
 
-_See code: [src/commands/agent/preview/end.ts](https://github.com/salesforcecli/plugin-agent/blob/1.42.1/src/commands/agent/preview/end.ts)_
+_See code: [src/commands/agent/preview/end.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/preview/end.ts)_
 
 ## `sf agent preview send`
 
@@ -1153,7 +1490,7 @@ EXAMPLES
     $ sf agent preview send --utterance "what can you help me with?" --authoring-bundle My_Local_Agent
 ```
 
-_See code: [src/commands/agent/preview/send.ts](https://github.com/salesforcecli/plugin-agent/blob/1.42.1/src/commands/agent/preview/send.ts)_
+_See code: [src/commands/agent/preview/send.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/preview/send.ts)_
 
 ## `sf agent preview sessions`
 
@@ -1186,7 +1523,7 @@ EXAMPLES
     $ sf agent preview sessions
 ```
 
-_See code: [src/commands/agent/preview/sessions.ts](https://github.com/salesforcecli/plugin-agent/blob/1.42.1/src/commands/agent/preview/sessions.ts)_
+_See code: [src/commands/agent/preview/sessions.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/preview/sessions.ts)_
 
 ## `sf agent preview start`
 
@@ -1251,7 +1588,7 @@ EXAMPLES
     $ sf agent preview start --api-name My_Published_Agent
 ```
 
-_See code: [src/commands/agent/preview/start.ts](https://github.com/salesforcecli/plugin-agent/blob/1.42.1/src/commands/agent/preview/start.ts)_
+_See code: [src/commands/agent/preview/start.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/preview/start.ts)_
 
 ## `sf agent publish authoring-bundle`
 
@@ -1311,7 +1648,7 @@ EXAMPLES
     $ sf agent publish authoring-bundle --api-name MyAuthoringbundle --concise
 ```
 
-_See code: [src/commands/agent/publish/authoring-bundle.ts](https://github.com/salesforcecli/plugin-agent/blob/1.42.1/src/commands/agent/publish/authoring-bundle.ts)_
+_See code: [src/commands/agent/publish/authoring-bundle.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/publish/authoring-bundle.ts)_
 
 ## `sf agent test create`
 
@@ -1383,7 +1720,7 @@ FLAG DESCRIPTIONS
     metadata. 'testing-center' uses AiEvaluationDefinition metadata.
 ```
 
-_See code: [src/commands/agent/test/create.ts](https://github.com/salesforcecli/plugin-agent/blob/1.42.1/src/commands/agent/test/create.ts)_
+_See code: [src/commands/agent/test/create.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/test/create.ts)_
 
 ## `sf agent test list`
 
@@ -1418,7 +1755,7 @@ EXAMPLES
     $ sf agent test list --target-org my-org
 ```
 
-_See code: [src/commands/agent/test/list.ts](https://github.com/salesforcecli/plugin-agent/blob/1.42.1/src/commands/agent/test/list.ts)_
+_See code: [src/commands/agent/test/list.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/test/list.ts)_
 
 ## `sf agent test results`
 
@@ -1494,7 +1831,7 @@ FLAG DESCRIPTIONS
     expression when using custom evaluations.
 ```
 
-_See code: [src/commands/agent/test/results.ts](https://github.com/salesforcecli/plugin-agent/blob/1.42.1/src/commands/agent/test/results.ts)_
+_See code: [src/commands/agent/test/results.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/test/results.ts)_
 
 ## `sf agent test resume`
 
@@ -1578,7 +1915,7 @@ FLAG DESCRIPTIONS
     expression when using custom evaluations.
 ```
 
-_See code: [src/commands/agent/test/resume.ts](https://github.com/salesforcecli/plugin-agent/blob/1.42.1/src/commands/agent/test/resume.ts)_
+_See code: [src/commands/agent/test/resume.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/test/resume.ts)_
 
 ## `sf agent test run`
 
@@ -1662,7 +1999,7 @@ FLAG DESCRIPTIONS
     expression when using custom evaluations.
 ```
 
-_See code: [src/commands/agent/test/run.ts](https://github.com/salesforcecli/plugin-agent/blob/1.42.1/src/commands/agent/test/run.ts)_
+_See code: [src/commands/agent/test/run.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/test/run.ts)_
 
 ## `sf agent test run-eval`
 
@@ -1738,7 +2075,7 @@ EXAMPLES
   $ echo '{"tests":[...]}' | sf agent test run-eval --spec --target-org my-org
 ```
 
-_See code: [src/commands/agent/test/run-eval.ts](https://github.com/salesforcecli/plugin-agent/blob/1.42.1/src/commands/agent/test/run-eval.ts)_
+_See code: [src/commands/agent/test/run-eval.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/test/run-eval.ts)_
 
 ## `sf agent trace delete`
 
@@ -1802,7 +2139,7 @@ EXAMPLES
     $ sf agent trace delete --no-prompt
 ```
 
-_See code: [src/commands/agent/trace/delete.ts](https://github.com/salesforcecli/plugin-agent/blob/1.42.1/src/commands/agent/trace/delete.ts)_
+_See code: [src/commands/agent/trace/delete.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/trace/delete.ts)_
 
 ## `sf agent trace list`
 
@@ -1872,7 +2209,7 @@ FLAG DESCRIPTIONS
     (2026-04-20T14:00:00.000Z). The "Recorded At" values shown in the table output are valid inputs.
 ```
 
-_See code: [src/commands/agent/trace/list.ts](https://github.com/salesforcecli/plugin-agent/blob/1.42.1/src/commands/agent/trace/list.ts)_
+_See code: [src/commands/agent/trace/list.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/trace/list.ts)_
 
 ## `sf agent trace read`
 
@@ -1960,7 +2297,7 @@ EXAMPLES
     $ sf agent trace read --session-id <SESSION_ID> --json
 ```
 
-_See code: [src/commands/agent/trace/read.ts](https://github.com/salesforcecli/plugin-agent/blob/1.42.1/src/commands/agent/trace/read.ts)_
+_See code: [src/commands/agent/trace/read.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/trace/read.ts)_
 
 ## `sf agent validate authoring-bundle`
 
@@ -2007,6 +2344,5 @@ EXAMPLES
     $ sf agent validate authoring-bundle --api-name MyAuthoringBundle --target-org my-dev-org
 ```
 
-_See code: [src/commands/agent/validate/authoring-bundle.ts](https://github.com/salesforcecli/plugin-agent/blob/1.42.1/src/commands/agent/validate/authoring-bundle.ts)_
-
+_See code: [src/commands/agent/validate/authoring-bundle.ts](https://github.com/salesforcecli/plugin-agent/blob/v1.42.1/src/commands/agent/validate/authoring-bundle.ts)_
 <!-- commandsstop -->

--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -360,6 +360,7 @@
     ],
     "flags": [
       "api-version",
+      "assets",
       "assets-file",
       "flags-dir",
       "json",

--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -3,15 +3,28 @@
     "alias": [],
     "command": "agent:activate",
     "flagAliases": [],
-    "flagChars": ["n", "o"],
-    "flags": ["api-name", "api-version", "flags-dir", "json", "target-org", "version"],
+    "flagChars": [
+      "n",
+      "o"
+    ],
+    "flags": [
+      "api-name",
+      "api-version",
+      "flags-dir",
+      "json",
+      "target-org",
+      "version"
+    ],
     "plugin": "@salesforce/plugin-agent"
   },
   {
     "alias": [],
     "command": "agent:adl:create",
     "flagAliases": [],
-    "flagChars": ["n", "o"],
+    "flagChars": [
+      "n",
+      "o"
+    ],
     "flags": [
       "api-version",
       "description",
@@ -32,63 +45,132 @@
     "alias": [],
     "command": "agent:adl:delete",
     "flagAliases": [],
-    "flagChars": ["i", "o"],
-    "flags": ["api-version", "flags-dir", "json", "library-id", "target-org"],
+    "flagChars": [
+      "i",
+      "o"
+    ],
+    "flags": [
+      "api-version",
+      "flags-dir",
+      "json",
+      "library-id",
+      "target-org"
+    ],
     "plugin": "@salesforce/plugin-agent"
   },
   {
     "alias": [],
     "command": "agent:adl:file:add",
     "flagAliases": [],
-    "flagChars": ["f", "i", "o"],
-    "flags": ["api-version", "flags-dir", "json", "library-id", "path", "target-org"],
+    "flagChars": [
+      "f",
+      "i",
+      "o"
+    ],
+    "flags": [
+      "api-version",
+      "flags-dir",
+      "json",
+      "library-id",
+      "path",
+      "target-org"
+    ],
     "plugin": "@salesforce/plugin-agent"
   },
   {
     "alias": [],
     "command": "agent:adl:file:delete",
     "flagAliases": [],
-    "flagChars": ["i", "o"],
-    "flags": ["api-version", "file-id", "flags-dir", "json", "library-id", "target-org"],
+    "flagChars": [
+      "i",
+      "o"
+    ],
+    "flags": [
+      "api-version",
+      "file-id",
+      "flags-dir",
+      "json",
+      "library-id",
+      "target-org"
+    ],
     "plugin": "@salesforce/plugin-agent"
   },
   {
     "alias": [],
     "command": "agent:adl:file:list",
     "flagAliases": [],
-    "flagChars": ["i", "o"],
-    "flags": ["api-version", "flags-dir", "json", "library-id", "target-org"],
+    "flagChars": [
+      "i",
+      "o"
+    ],
+    "flags": [
+      "api-version",
+      "flags-dir",
+      "json",
+      "library-id",
+      "target-org"
+    ],
     "plugin": "@salesforce/plugin-agent"
   },
   {
     "alias": [],
     "command": "agent:adl:get",
     "flagAliases": [],
-    "flagChars": ["i", "o"],
-    "flags": ["api-version", "flags-dir", "json", "library-id", "target-org"],
+    "flagChars": [
+      "i",
+      "o"
+    ],
+    "flags": [
+      "api-version",
+      "flags-dir",
+      "json",
+      "library-id",
+      "target-org"
+    ],
     "plugin": "@salesforce/plugin-agent"
   },
   {
     "alias": [],
     "command": "agent:adl:list",
     "flagAliases": [],
-    "flagChars": ["o"],
-    "flags": ["api-version", "flags-dir", "json", "source-type", "target-org"],
+    "flagChars": [
+      "o"
+    ],
+    "flags": [
+      "api-version",
+      "flags-dir",
+      "json",
+      "source-type",
+      "target-org"
+    ],
     "plugin": "@salesforce/plugin-agent"
   },
   {
     "alias": [],
     "command": "agent:adl:status",
     "flagAliases": [],
-    "flagChars": ["i", "o"],
-    "flags": ["api-version", "flags-dir", "json", "library-id", "target-org"],
+    "flagChars": [
+      "i",
+      "o"
+    ],
+    "flags": [
+      "api-version",
+      "flags-dir",
+      "json",
+      "library-id",
+      "target-org"
+    ],
     "plugin": "@salesforce/plugin-agent"
   },
   {
     "alias": [],
     "command": "agent:adl:update",
     "flagAliases": [],
-    "flagChars": ["i", "n", "o"],
+    "flagChars": [
+      "i",
+      "n",
+      "o"
+    ],
     "flags": [
       "api-version",
       "content-fields",
@@ -107,31 +189,67 @@
     "alias": [],
     "command": "agent:adl:upload",
     "flagAliases": [],
-    "flagChars": ["f", "i", "o", "w"],
-    "flags": ["api-version", "file", "flags-dir", "json", "library-id", "target-org", "wait"],
+    "flagChars": [
+      "f",
+      "i",
+      "o",
+      "w"
+    ],
+    "flags": [
+      "api-version",
+      "file",
+      "flags-dir",
+      "json",
+      "library-id",
+      "target-org",
+      "wait"
+    ],
     "plugin": "@salesforce/plugin-agent"
   },
   {
     "alias": [],
     "command": "agent:create",
     "flagAliases": [],
-    "flagChars": ["o"],
-    "flags": ["api-name", "api-version", "flags-dir", "json", "name", "planner-id", "preview", "spec", "target-org"],
+    "flagChars": [
+      "o"
+    ],
+    "flags": [
+      "api-name",
+      "api-version",
+      "flags-dir",
+      "json",
+      "name",
+      "planner-id",
+      "preview",
+      "spec",
+      "target-org"
+    ],
     "plugin": "@salesforce/plugin-agent"
   },
   {
     "alias": [],
     "command": "agent:deactivate",
     "flagAliases": [],
-    "flagChars": ["n", "o"],
-    "flags": ["api-name", "api-version", "flags-dir", "json", "target-org"],
+    "flagChars": [
+      "n",
+      "o"
+    ],
+    "flags": [
+      "api-name",
+      "api-version",
+      "flags-dir",
+      "json",
+      "target-org"
+    ],
     "plugin": "@salesforce/plugin-agent"
   },
   {
     "alias": [],
     "command": "agent:generate:agent-spec",
     "flagAliases": [],
-    "flagChars": ["o"],
+    "flagChars": [
+      "o"
+    ],
     "flags": [
       "agent-user",
       "api-version",
@@ -159,7 +277,12 @@
     "alias": [],
     "command": "agent:generate:authoring-bundle",
     "flagAliases": [],
-    "flagChars": ["d", "f", "n", "o"],
+    "flagChars": [
+      "d",
+      "f",
+      "n",
+      "o"
+    ],
     "flags": [
       "api-name",
       "api-version",
@@ -178,23 +301,203 @@
     "alias": [],
     "command": "agent:generate:template",
     "flagAliases": [],
-    "flagChars": ["f", "r", "s"],
-    "flags": ["agent-file", "agent-version", "api-version", "flags-dir", "json", "output-dir", "source-org"],
+    "flagChars": [
+      "f",
+      "r",
+      "s"
+    ],
+    "flags": [
+      "agent-file",
+      "agent-version",
+      "api-version",
+      "flags-dir",
+      "json",
+      "output-dir",
+      "source-org"
+    ],
     "plugin": "@salesforce/plugin-agent"
   },
   {
     "alias": [],
     "command": "agent:generate:test-spec",
     "flagAliases": [],
-    "flagChars": ["d", "f"],
-    "flags": ["flags-dir", "force-overwrite", "from-definition", "output-file"],
+    "flagChars": [
+      "d",
+      "f"
+    ],
+    "flags": [
+      "flags-dir",
+      "force-overwrite",
+      "from-definition",
+      "output-file"
+    ],
+    "plugin": "@salesforce/plugin-agent"
+  },
+  {
+    "alias": [],
+    "command": "agent:mcp:asset:list",
+    "flagAliases": [],
+    "flagChars": [
+      "i",
+      "o"
+    ],
+    "flags": [
+      "api-version",
+      "flags-dir",
+      "json",
+      "mcp-server-id",
+      "target-org"
+    ],
+    "plugin": "@salesforce/plugin-agent"
+  },
+  {
+    "alias": [],
+    "command": "agent:mcp:asset:replace",
+    "flagAliases": [],
+    "flagChars": [
+      "i",
+      "o"
+    ],
+    "flags": [
+      "api-version",
+      "assets-file",
+      "flags-dir",
+      "json",
+      "mcp-server-id",
+      "target-org"
+    ],
+    "plugin": "@salesforce/plugin-agent"
+  },
+  {
+    "alias": [],
+    "command": "agent:mcp:create",
+    "flagAliases": [],
+    "flagChars": [
+      "n",
+      "o"
+    ],
+    "flags": [
+      "api-version",
+      "auth-type",
+      "client-id",
+      "client-secret",
+      "description",
+      "flags-dir",
+      "identity-provider",
+      "json",
+      "label",
+      "name",
+      "scope",
+      "server-url",
+      "target-org"
+    ],
+    "plugin": "@salesforce/plugin-agent"
+  },
+  {
+    "alias": [],
+    "command": "agent:mcp:delete",
+    "flagAliases": [],
+    "flagChars": [
+      "i",
+      "o"
+    ],
+    "flags": [
+      "api-version",
+      "flags-dir",
+      "json",
+      "mcp-server-id",
+      "no-prompt",
+      "target-org"
+    ],
+    "plugin": "@salesforce/plugin-agent"
+  },
+  {
+    "alias": [],
+    "command": "agent:mcp:fetch",
+    "flagAliases": [],
+    "flagChars": [
+      "i",
+      "o"
+    ],
+    "flags": [
+      "api-version",
+      "flags-dir",
+      "json",
+      "mcp-server-id",
+      "target-org"
+    ],
+    "plugin": "@salesforce/plugin-agent"
+  },
+  {
+    "alias": [],
+    "command": "agent:mcp:get",
+    "flagAliases": [],
+    "flagChars": [
+      "i",
+      "o"
+    ],
+    "flags": [
+      "api-version",
+      "flags-dir",
+      "json",
+      "mcp-server-id",
+      "target-org"
+    ],
+    "plugin": "@salesforce/plugin-agent"
+  },
+  {
+    "alias": [],
+    "command": "agent:mcp:list",
+    "flagAliases": [],
+    "flagChars": [
+      "o"
+    ],
+    "flags": [
+      "api-version",
+      "flags-dir",
+      "json",
+      "label",
+      "status",
+      "target-org",
+      "type"
+    ],
+    "plugin": "@salesforce/plugin-agent"
+  },
+  {
+    "alias": [],
+    "command": "agent:mcp:update",
+    "flagAliases": [],
+    "flagChars": [
+      "i",
+      "o"
+    ],
+    "flags": [
+      "api-version",
+      "auth-type",
+      "client-id",
+      "client-secret",
+      "description",
+      "flags-dir",
+      "identity-provider",
+      "json",
+      "label",
+      "mcp-server-id",
+      "scope",
+      "server-url",
+      "target-org"
+    ],
     "plugin": "@salesforce/plugin-agent"
   },
   {
     "alias": [],
     "command": "agent:preview",
     "flagAliases": [],
-    "flagChars": ["d", "n", "o", "x"],
+    "flagChars": [
+      "d",
+      "n",
+      "o",
+      "x"
+    ],
     "flags": [
       "agent-json",
       "apex-debug",
@@ -212,7 +515,11 @@
     "alias": [],
     "command": "agent:preview:end",
     "flagAliases": [],
-    "flagChars": ["n", "o", "p"],
+    "flagChars": [
+      "n",
+      "o",
+      "p"
+    ],
     "flags": [
       "all",
       "api-name",
@@ -230,7 +537,11 @@
     "alias": [],
     "command": "agent:preview:send",
     "flagAliases": [],
-    "flagChars": ["n", "o", "u"],
+    "flagChars": [
+      "n",
+      "o",
+      "u"
+    ],
     "flags": [
       "api-name",
       "api-version",
@@ -248,14 +559,20 @@
     "command": "agent:preview:sessions",
     "flagAliases": [],
     "flagChars": [],
-    "flags": ["flags-dir", "json"],
+    "flags": [
+      "flags-dir",
+      "json"
+    ],
     "plugin": "@salesforce/plugin-agent"
   },
   {
     "alias": [],
     "command": "agent:preview:start",
     "flagAliases": [],
-    "flagChars": ["n", "o"],
+    "flagChars": [
+      "n",
+      "o"
+    ],
     "flags": [
       "agent-json",
       "api-name",
@@ -273,15 +590,30 @@
     "alias": [],
     "command": "agent:publish:authoring-bundle",
     "flagAliases": [],
-    "flagChars": ["n", "o", "v"],
-    "flags": ["api-name", "api-version", "concise", "flags-dir", "json", "skip-retrieve", "target-org", "verbose"],
+    "flagChars": [
+      "n",
+      "o",
+      "v"
+    ],
+    "flags": [
+      "api-name",
+      "api-version",
+      "concise",
+      "flags-dir",
+      "json",
+      "skip-retrieve",
+      "target-org",
+      "verbose"
+    ],
     "plugin": "@salesforce/plugin-agent"
   },
   {
     "alias": [],
     "command": "agent:test:create",
     "flagAliases": [],
-    "flagChars": ["o"],
+    "flagChars": [
+      "o"
+    ],
     "flags": [
       "api-name",
       "api-version",
@@ -299,15 +631,26 @@
     "alias": [],
     "command": "agent:test:list",
     "flagAliases": [],
-    "flagChars": ["o"],
-    "flags": ["api-version", "flags-dir", "json", "target-org"],
+    "flagChars": [
+      "o"
+    ],
+    "flags": [
+      "api-version",
+      "flags-dir",
+      "json",
+      "target-org"
+    ],
     "plugin": "@salesforce/plugin-agent"
   },
   {
     "alias": [],
     "command": "agent:test:results",
     "flagAliases": [],
-    "flagChars": ["d", "i", "o"],
+    "flagChars": [
+      "d",
+      "i",
+      "o"
+    ],
     "flags": [
       "api-version",
       "flags-dir",
@@ -325,7 +668,13 @@
     "alias": [],
     "command": "agent:test:resume",
     "flagAliases": [],
-    "flagChars": ["d", "i", "o", "r", "w"],
+    "flagChars": [
+      "d",
+      "i",
+      "o",
+      "r",
+      "w"
+    ],
     "flags": [
       "api-version",
       "flags-dir",
@@ -345,7 +694,12 @@
     "alias": [],
     "command": "agent:test:run",
     "flagAliases": [],
-    "flagChars": ["d", "n", "o", "w"],
+    "flagChars": [
+      "d",
+      "n",
+      "o",
+      "w"
+    ],
     "flags": [
       "api-name",
       "api-version",
@@ -364,7 +718,11 @@
     "alias": [],
     "command": "agent:test:run-eval",
     "flagAliases": [],
-    "flagChars": ["n", "o", "s"],
+    "flagChars": [
+      "n",
+      "o",
+      "s"
+    ],
     "flags": [
       "api-name",
       "api-version",
@@ -382,32 +740,70 @@
     "alias": [],
     "command": "agent:trace:delete",
     "flagAliases": [],
-    "flagChars": ["a"],
-    "flags": ["agent", "flags-dir", "json", "no-prompt", "older-than", "session-id"],
+    "flagChars": [
+      "a"
+    ],
+    "flags": [
+      "agent",
+      "flags-dir",
+      "json",
+      "no-prompt",
+      "older-than",
+      "session-id"
+    ],
     "plugin": "@salesforce/plugin-agent"
   },
   {
     "alias": [],
     "command": "agent:trace:list",
     "flagAliases": [],
-    "flagChars": ["a"],
-    "flags": ["agent", "flags-dir", "json", "session-id", "since"],
+    "flagChars": [
+      "a"
+    ],
+    "flags": [
+      "agent",
+      "flags-dir",
+      "json",
+      "session-id",
+      "since"
+    ],
     "plugin": "@salesforce/plugin-agent"
   },
   {
     "alias": [],
     "command": "agent:trace:read",
     "flagAliases": [],
-    "flagChars": ["d", "f", "s", "t"],
-    "flags": ["dimension", "flags-dir", "format", "json", "session-id", "turn"],
+    "flagChars": [
+      "d",
+      "f",
+      "s",
+      "t"
+    ],
+    "flags": [
+      "dimension",
+      "flags-dir",
+      "format",
+      "json",
+      "session-id",
+      "turn"
+    ],
     "plugin": "@salesforce/plugin-agent"
   },
   {
     "alias": [],
     "command": "agent:validate:authoring-bundle",
     "flagAliases": [],
-    "flagChars": ["n", "o"],
-    "flags": ["api-name", "api-version", "flags-dir", "json", "target-org"],
+    "flagChars": [
+      "n",
+      "o"
+    ],
+    "flags": [
+      "api-name",
+      "api-version",
+      "flags-dir",
+      "json",
+      "target-org"
+    ],
     "plugin": "@salesforce/plugin-agent"
   }
 ]

--- a/messages/agent.mcp.asset.list.md
+++ b/messages/agent.mcp.asset.list.md
@@ -1,0 +1,25 @@
+# summary
+
+List the assets (tools, prompts, and resources) for an MCP server in the catalog.
+
+# description
+
+Returns the assets discovered for the specified MCP server, including each asset's kind (MCP_TOOL, MCP_PROMPT, or MCP_RESOURCE), whether it is active, and whether it is available as an agent action.
+
+# examples
+
+- List the assets for an MCP server in the default target org:
+
+  <%= config.bin %> <%= command.id %> --target-org myOrg --mcp-server-id 0XSxx0000000001
+
+- List the assets for an MCP server and output as JSON:
+
+  <%= config.bin %> <%= command.id %> --target-org myOrg --mcp-server-id 0XSxx0000000001 --json
+
+# flags.mcp-server-id.summary
+
+The ID of the MCP server whose assets you want to list.
+
+# error.failed
+
+Failed to list MCP server assets: %s

--- a/messages/agent.mcp.asset.replace.md
+++ b/messages/agent.mcp.asset.replace.md
@@ -1,0 +1,37 @@
+# summary
+
+Replace the asset set of an MCP server in the API Catalog.
+
+# description
+
+Replaces the full set of assets (tools, prompts, resources) for an MCP server with the asset items supplied in a JSON file. The file must contain either a JSON array of asset items or an object of the form `{ "assets": [...] }`. Each asset item may include `id`, `name`, `label`, `description`, `active`, and `kind`. Existing assets not present in the supplied set may be removed, so provide the complete desired asset set.
+
+# examples
+
+- Replace the assets of an MCP server using a JSON file that contains an array of asset items:
+
+  <%= config.bin %> <%= command.id %> --mcp-server-id 0XSxx0000000001 --assets-file ./assets.json --target-org myOrg
+
+- Replace the assets and output the result as JSON:
+
+  <%= config.bin %> <%= command.id %> --mcp-server-id 0XSxx0000000001 --assets-file ./assets.json --target-org myOrg --json
+
+# flags.mcp-server-id.summary
+
+ID of the MCP server whose assets you want to replace.
+
+# flags.assets-file.summary
+
+Path to a JSON file containing an array of asset items or an object of the form { "assets": [...] }.
+
+# error.failed
+
+Failed to replace MCP server assets: %s
+
+# error.invalidJson
+
+The assets file does not contain valid JSON.
+
+# error.invalidShape
+
+The assets file must contain a JSON array of asset items or an object with an "assets" array.

--- a/messages/agent.mcp.asset.replace.md
+++ b/messages/agent.mcp.asset.replace.md
@@ -4,34 +4,46 @@ Replace the asset set of an MCP server in the API Catalog.
 
 # description
 
-Replaces the full set of assets (tools, prompts, resources) for an MCP server with the asset items supplied in a JSON file. The file must contain either a JSON array of asset items or an object of the form `{ "assets": [...] }`. Each asset item may include `id`, `name`, `label`, `description`, `active`, and `kind`. Existing assets not present in the supplied set may be removed, so provide the complete desired asset set.
+Replaces the full set of assets (tools, prompts, resources) for an MCP server with the asset items you supply. Provide the assets either inline with `--assets` (a JSON string, or `-` to read from stdin) or from a file with `--assets-file`. The JSON must be either an array of asset items or an object of the form `{ "assets": [...] }`. Each asset item may include `id`, `name`, `label`, `description`, `active`, and `kind`. This is a full replacement: existing assets not present in the supplied set are removed, so provide the complete desired asset set (read the current set first with `agent mcp asset list` or `agent mcp fetch`).
 
 # examples
 
-- Replace the assets of an MCP server using a JSON file that contains an array of asset items:
+- Replace the assets inline with a JSON string:
+
+  <%= config.bin %> <%= command.id %> --mcp-server-id 0XSxx0000000001 --assets '{"assets":[{"name":"McpTool__add","active":true}]}' --target-org myOrg
+
+- Replace the assets from a JSON file:
 
   <%= config.bin %> <%= command.id %> --mcp-server-id 0XSxx0000000001 --assets-file ./assets.json --target-org myOrg
 
-- Replace the assets and output the result as JSON:
+- Pipe the assets from stdin:
 
-  <%= config.bin %> <%= command.id %> --mcp-server-id 0XSxx0000000001 --assets-file ./assets.json --target-org myOrg --json
+  cat assets.json | <%= config.bin %> <%= command.id %> --mcp-server-id 0XSxx0000000001 --assets - --target-org myOrg
 
 # flags.mcp-server-id.summary
 
 ID of the MCP server whose assets you want to replace.
 
+# flags.assets.summary
+
+The desired asset allowlist as a JSON string (or "-" to read from stdin). Mutually exclusive with --assets-file.
+
 # flags.assets-file.summary
 
-Path to a JSON file containing an array of asset items or an object of the form { "assets": [...] }.
+Path to a JSON file containing the desired asset allowlist. Mutually exclusive with --assets.
 
 # error.failed
 
 Failed to replace MCP server assets: %s
 
+# error.noInput
+
+Provide the assets either inline with --assets or from a file with --assets-file.
+
 # error.invalidJson
 
-The assets file does not contain valid JSON.
+The assets input does not contain valid JSON.
 
 # error.invalidShape
 
-The assets file must contain a JSON array of asset items or an object with an "assets" array.
+The assets input must be a JSON array of asset items or an object with an "assets" array.

--- a/messages/agent.mcp.create.md
+++ b/messages/agent.mcp.create.md
@@ -1,0 +1,61 @@
+# summary
+
+Create an MCP server in the API Catalog.
+
+# description
+
+Registers an external Model Context Protocol (MCP) server with the API Catalog and discovers its assets (tools, prompts, and resources). Provide the server URL and, when the server requires it, OAuth authorization details. When the authorization type is OAUTH you must supply the identity provider, client ID, client secret, and scope.
+
+# examples
+
+- Create an MCP server with no authentication:
+
+  <%= config.bin %> <%= command.id %> --name myServer --server-url https://mcp.example.com --target-org myOrg
+
+- Create an MCP server that uses OAuth authentication, piping the client secret from stdin to keep it out of shell history:
+
+  cat secret.txt | <%= config.bin %> <%= command.id %> --name myServer --server-url https://mcp.example.com --auth-type OAUTH --identity-provider myIdp --client-id abc123 --client-secret - --scope "read write" --target-org myOrg
+
+# flags.name.summary
+
+Unique name of the MCP server.
+
+# flags.label.summary
+
+Human-readable label for the MCP server.
+
+# flags.description.summary
+
+Description of the MCP server.
+
+# flags.server-url.summary
+
+URL of the external MCP server.
+
+# flags.auth-type.summary
+
+Authorization type to use when connecting to the MCP server.
+
+# flags.identity-provider.summary
+
+Identity provider to use for OAuth authorization. Required when auth-type is OAUTH.
+
+# flags.client-id.summary
+
+OAuth client ID. Required when auth-type is OAUTH.
+
+# flags.client-secret.summary
+
+OAuth client secret. Required when auth-type is OAUTH. Pass "-" to read it from stdin (piped) and keep it out of shell history.
+
+# flags.scope.summary
+
+OAuth scope to request. Required when auth-type is OAUTH.
+
+# error.missingOauthFields
+
+When auth-type is OAUTH you must provide --identity-provider, --client-id, --client-secret, and --scope.
+
+# error.failed
+
+Failed to create MCP server: %s

--- a/messages/agent.mcp.delete.md
+++ b/messages/agent.mcp.delete.md
@@ -1,0 +1,37 @@
+# summary
+
+Delete an MCP server from the API Catalog.
+
+# description
+
+Permanently removes an MCP (Model Context Protocol) server registration from the API Catalog, identified by its ID. By default you are prompted to confirm the deletion; pass --no-prompt to skip the confirmation (for example in scripts and CI).
+
+# examples
+
+- Delete an MCP server, confirming interactively:
+
+  <%= config.bin %> <%= command.id %> --mcp-server-id 0XSxx0000000001 --target-org myOrg
+
+- Delete an MCP server without a confirmation prompt:
+
+  <%= config.bin %> <%= command.id %> --mcp-server-id 0XSxx0000000001 --target-org myOrg --no-prompt
+
+# flags.mcp-server-id.summary
+
+ID of the MCP server to delete.
+
+# flags.no-prompt.summary
+
+Skip the confirmation prompt and delete the MCP server immediately.
+
+# confirm.delete
+
+Are you sure you want to delete the MCP server %s? This action cannot be undone.
+
+# error.aborted
+
+Deletion aborted: the operation was not confirmed.
+
+# error.failed
+
+Failed to delete MCP server: %s

--- a/messages/agent.mcp.fetch.md
+++ b/messages/agent.mcp.fetch.md
@@ -1,0 +1,25 @@
+# summary
+
+Fetch the live assets (tools, prompts, resources) advertised by an MCP server.
+
+# description
+
+Performs a live fetch against the configured MCP server identified by its ID, returning the assets (MCP tools, prompts, and resources) it currently advertises along with their status and activation state. Use this to refresh the view of what an MCP server exposes before activating its assets as agent actions.
+
+# examples
+
+- Fetch the assets advertised by an MCP server in the default target org:
+
+  <%= config.bin %> <%= command.id %> --target-org myOrg --mcp-server-id 0XSxx0000000001
+
+- Fetch MCP server assets and output as JSON:
+
+  <%= config.bin %> <%= command.id %> --target-org myOrg --mcp-server-id 0XSxx0000000001 --json
+
+# flags.mcp-server-id.summary
+
+ID of the MCP server to fetch assets from.
+
+# error.failed
+
+Failed to fetch MCP server assets: %s

--- a/messages/agent.mcp.get.md
+++ b/messages/agent.mcp.get.md
@@ -1,0 +1,25 @@
+# summary
+
+Get a single MCP server registered in the API Catalog.
+
+# description
+
+Retrieves the details of an MCP (Model Context Protocol) server by its identifier, including its name, label, type, status, and server URL.
+
+# examples
+
+- Get an MCP server by id in the default target org:
+
+  <%= config.bin %> <%= command.id %> --target-org myOrg --mcp-server-id 0Mx000000000001
+
+- Get an MCP server and output as JSON:
+
+  <%= config.bin %> <%= command.id %> --target-org myOrg --mcp-server-id 0Mx000000000001 --json
+
+# flags.mcp-server-id.summary
+
+The identifier of the MCP server to retrieve.
+
+# error.failed
+
+Failed to get MCP server: %s

--- a/messages/agent.mcp.list.md
+++ b/messages/agent.mcp.list.md
@@ -1,0 +1,33 @@
+# summary
+
+List the MCP servers registered in the API Catalog.
+
+# description
+
+Returns the Model Context Protocol (MCP) servers registered in the API Catalog, optionally filtered by label, type, or status. Use this to discover which MCP servers are available and inspect their server URLs and current status.
+
+# examples
+
+- List all MCP servers in the default target org:
+
+  <%= config.bin %> <%= command.id %> --target-org myOrg
+
+- List external MCP servers filtered by status and output as JSON:
+
+  <%= config.bin %> <%= command.id %> --target-org myOrg --type EXTERNAL --status ACTIVE --json
+
+# flags.label.summary
+
+Filter the MCP servers by label.
+
+# flags.type.summary
+
+Filter the MCP servers by type.
+
+# flags.status.summary
+
+Filter the MCP servers by connection status. Only ACTIVE and DISCONNECTED are supported as filters.
+
+# error.failed
+
+Failed to list MCP servers: %s

--- a/messages/agent.mcp.update.md
+++ b/messages/agent.mcp.update.md
@@ -1,0 +1,65 @@
+# summary
+
+Update an MCP server registered in the API Catalog.
+
+# description
+
+Updates an existing MCP server in the API Catalog. Only the fields you provide are changed; omitted fields are left untouched. You can update the label, description, and server URL, and replace the authorization configuration. When setting `--auth-type OAUTH`, you must also provide `--identity-provider`, `--client-id`, `--client-secret`, and `--scope`. When setting `--auth-type NO_AUTH`, no authorization credentials are required. At least one updatable field must be supplied.
+
+# examples
+
+- Update the label and description of an MCP server in the default target org:
+
+  <%= config.bin %> <%= command.id %> --mcp-server-id 0XSxx0000000001 --label "Orders MCP" --description "Order tooling" --target-org myOrg
+
+- Update the server URL and switch the authorization to OAuth, piping the client secret from stdin and outputting as JSON:
+
+  cat secret.txt | <%= config.bin %> <%= command.id %> --mcp-server-id 0XSxx0000000001 --server-url https://mcp.example.com --auth-type OAUTH --identity-provider MyIdp --client-id abc --client-secret - --scope "read write" --target-org myOrg --json
+
+# flags.mcp-server-id.summary
+
+ID of the MCP server to update.
+
+# flags.label.summary
+
+New display label for the MCP server.
+
+# flags.description.summary
+
+New description for the MCP server.
+
+# flags.server-url.summary
+
+New endpoint URL of the MCP server.
+
+# flags.auth-type.summary
+
+Authorization type to apply to the MCP server (OAUTH or NO_AUTH).
+
+# flags.identity-provider.summary
+
+Identity provider name for OAuth authorization (required when --auth-type is OAUTH).
+
+# flags.client-id.summary
+
+OAuth client ID (required when --auth-type is OAUTH).
+
+# flags.client-secret.summary
+
+OAuth client secret (required when --auth-type is OAUTH). Pass "-" to read it from stdin (piped) and keep it out of shell history.
+
+# flags.scope.summary
+
+OAuth scope (required when --auth-type is OAUTH).
+
+# error.failed
+
+Failed to update MCP server: %s
+
+# error.noFields
+
+No fields to update. Provide at least one of --label, --description, --server-url, or --auth-type.
+
+# error.missingOauthFields
+
+OAuth authorization requires --identity-provider, --client-id, --client-secret, and --scope.

--- a/package.json
+++ b/package.json
@@ -104,6 +104,16 @@
                 "external": true
               }
             }
+          },
+          "mcp": {
+            "description": "Commands to manage MCP server registrations in the API Catalog.",
+            "external": true,
+            "subtopics": {
+              "asset": {
+                "description": "Commands to manage the asset allowlist of an MCP server.",
+                "external": true
+              }
+            }
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@inquirer/prompts": "^7.10.1",
     "@oclif/core": "^4",
     "@oclif/multi-stage-output": "^0.8.36",
-    "@salesforce/agents": "^1.8.1",
+    "@salesforce/agents": "^1.8.4",
     "@salesforce/core": "^8.28.3",
     "@salesforce/kit": "^3.2.6",
     "@salesforce/sf-plugins-core": "^12.2.6",

--- a/schemas/agent-mcp-asset-list.json
+++ b/schemas/agent-mcp-asset-list.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/ApiCatalogMcpServerAssetListResult",
+  "definitions": {
+    "ApiCatalogMcpServerAssetListResult": {
+      "$ref": "#/definitions/McpServerAssetCollection"
+    },
+    "McpServerAssetCollection": {
+      "type": "object",
+      "properties": {
+        "assets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/McpServerAssetOutput"
+          }
+        }
+      },
+      "required": [
+        "assets"
+      ],
+      "additionalProperties": false
+    },
+    "McpServerAssetOutput": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "kind": {
+          "$ref": "#/definitions/McpAssetKind"
+        },
+        "active": {
+          "type": "boolean"
+        },
+        "availableAsAgentAction": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "kind",
+        "active"
+      ],
+      "additionalProperties": false
+    },
+    "McpAssetKind": {
+      "type": "string",
+      "enum": [
+        "MCP_TOOL",
+        "MCP_PROMPT",
+        "MCP_RESOURCE"
+      ]
+    }
+  }
+}

--- a/schemas/agent-mcp-asset-replace.json
+++ b/schemas/agent-mcp-asset-replace.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/ApiCatalogMcpServerAssetReplaceResult",
+  "definitions": {
+    "ApiCatalogMcpServerAssetReplaceResult": {
+      "$ref": "#/definitions/McpServerAssetCollection"
+    },
+    "McpServerAssetCollection": {
+      "type": "object",
+      "properties": {
+        "assets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/McpServerAssetOutput"
+          }
+        }
+      },
+      "required": [
+        "assets"
+      ],
+      "additionalProperties": false
+    },
+    "McpServerAssetOutput": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "kind": {
+          "$ref": "#/definitions/McpAssetKind"
+        },
+        "active": {
+          "type": "boolean"
+        },
+        "availableAsAgentAction": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "kind",
+        "active"
+      ],
+      "additionalProperties": false
+    },
+    "McpAssetKind": {
+      "type": "string",
+      "enum": [
+        "MCP_TOOL",
+        "MCP_PROMPT",
+        "MCP_RESOURCE"
+      ]
+    }
+  }
+}

--- a/schemas/agent-mcp-create.json
+++ b/schemas/agent-mcp-create.json
@@ -1,0 +1,144 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/McpServerCreateOutput",
+  "definitions": {
+    "McpServerCreateOutput": {
+      "type": "object",
+      "properties": {
+        "server": {
+          "$ref": "#/definitions/McpServerOutput"
+        },
+        "assets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/McpFetchedAsset"
+          }
+        }
+      },
+      "required": [
+        "server",
+        "assets"
+      ],
+      "additionalProperties": false
+    },
+    "McpServerOutput": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "type": {
+          "$ref": "#/definitions/McpServerType"
+        },
+        "status": {
+          "type": "string"
+        },
+        "serverUrl": {
+          "type": "string"
+        },
+        "authorization": {
+          "$ref": "#/definitions/McpServerAuthorizationOutput"
+        },
+        "createdById": {
+          "type": "string"
+        },
+        "createdDate": {
+          "type": "string"
+        },
+        "lastModifiedById": {
+          "type": "string"
+        },
+        "lastModifiedDate": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "type",
+        "status"
+      ],
+      "additionalProperties": false
+    },
+    "McpServerType": {
+      "type": "string",
+      "const": "EXTERNAL"
+    },
+    "McpServerAuthorizationOutput": {
+      "type": "object",
+      "properties": {
+        "authType": {
+          "$ref": "#/definitions/McpAuthType"
+        },
+        "identityProvider": {
+          "type": "string"
+        },
+        "scope": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "authType"
+      ],
+      "additionalProperties": false
+    },
+    "McpAuthType": {
+      "type": "string",
+      "enum": [
+        "OAUTH",
+        "NO_AUTH"
+      ]
+    },
+    "McpFetchedAsset": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "kind": {
+          "$ref": "#/definitions/McpAssetKind"
+        },
+        "active": {
+          "type": "boolean"
+        },
+        "availableAsAgentAction": {
+          "type": "boolean"
+        },
+        "status": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "kind"
+      ],
+      "additionalProperties": false
+    },
+    "McpAssetKind": {
+      "type": "string",
+      "enum": [
+        "MCP_TOOL",
+        "MCP_PROMPT",
+        "MCP_RESOURCE"
+      ]
+    }
+  }
+}

--- a/schemas/agent-mcp-delete.json
+++ b/schemas/agent-mcp-delete.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/ApiCatalogMcpServerDeleteResult",
+  "definitions": {
+    "ApiCatalogMcpServerDeleteResult": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "deleted": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "id",
+        "deleted"
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/schemas/agent-mcp-fetch.json
+++ b/schemas/agent-mcp-fetch.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/ApiCatalogMcpServerFetchResult",
+  "definitions": {
+    "ApiCatalogMcpServerFetchResult": {
+      "$ref": "#/definitions/McpServerFetchOutput"
+    },
+    "McpServerFetchOutput": {
+      "type": "object",
+      "properties": {
+        "assets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/McpFetchedAsset"
+          }
+        }
+      },
+      "required": [
+        "assets"
+      ],
+      "additionalProperties": false
+    },
+    "McpFetchedAsset": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "kind": {
+          "$ref": "#/definitions/McpAssetKind"
+        },
+        "active": {
+          "type": "boolean"
+        },
+        "availableAsAgentAction": {
+          "type": "boolean"
+        },
+        "status": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "kind"
+      ],
+      "additionalProperties": false
+    },
+    "McpAssetKind": {
+      "type": "string",
+      "enum": [
+        "MCP_TOOL",
+        "MCP_PROMPT",
+        "MCP_RESOURCE"
+      ]
+    }
+  }
+}

--- a/schemas/agent-mcp-get.json
+++ b/schemas/agent-mcp-get.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/ApiCatalogMcpServerGetResult",
+  "definitions": {
+    "ApiCatalogMcpServerGetResult": {
+      "$ref": "#/definitions/McpServerOutput"
+    },
+    "McpServerOutput": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "type": {
+          "$ref": "#/definitions/McpServerType"
+        },
+        "status": {
+          "type": "string"
+        },
+        "serverUrl": {
+          "type": "string"
+        },
+        "authorization": {
+          "$ref": "#/definitions/McpServerAuthorizationOutput"
+        },
+        "createdById": {
+          "type": "string"
+        },
+        "createdDate": {
+          "type": "string"
+        },
+        "lastModifiedById": {
+          "type": "string"
+        },
+        "lastModifiedDate": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "type",
+        "status"
+      ],
+      "additionalProperties": false
+    },
+    "McpServerType": {
+      "type": "string",
+      "const": "EXTERNAL"
+    },
+    "McpServerAuthorizationOutput": {
+      "type": "object",
+      "properties": {
+        "authType": {
+          "$ref": "#/definitions/McpAuthType"
+        },
+        "identityProvider": {
+          "type": "string"
+        },
+        "scope": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "authType"
+      ],
+      "additionalProperties": false
+    },
+    "McpAuthType": {
+      "type": "string",
+      "enum": [
+        "OAUTH",
+        "NO_AUTH"
+      ]
+    }
+  }
+}

--- a/schemas/agent-mcp-list.json
+++ b/schemas/agent-mcp-list.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/ApiCatalogMcpServerListResult",
+  "definitions": {
+    "ApiCatalogMcpServerListResult": {
+      "$ref": "#/definitions/McpServerCollection"
+    },
+    "McpServerCollection": {
+      "type": "object",
+      "properties": {
+        "mcpServers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/McpServerOutput"
+          }
+        }
+      },
+      "required": [
+        "mcpServers"
+      ],
+      "additionalProperties": false
+    },
+    "McpServerOutput": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "type": {
+          "$ref": "#/definitions/McpServerType"
+        },
+        "status": {
+          "type": "string"
+        },
+        "serverUrl": {
+          "type": "string"
+        },
+        "authorization": {
+          "$ref": "#/definitions/McpServerAuthorizationOutput"
+        },
+        "createdById": {
+          "type": "string"
+        },
+        "createdDate": {
+          "type": "string"
+        },
+        "lastModifiedById": {
+          "type": "string"
+        },
+        "lastModifiedDate": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "type",
+        "status"
+      ],
+      "additionalProperties": false
+    },
+    "McpServerType": {
+      "type": "string",
+      "const": "EXTERNAL"
+    },
+    "McpServerAuthorizationOutput": {
+      "type": "object",
+      "properties": {
+        "authType": {
+          "$ref": "#/definitions/McpAuthType"
+        },
+        "identityProvider": {
+          "type": "string"
+        },
+        "scope": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "authType"
+      ],
+      "additionalProperties": false
+    },
+    "McpAuthType": {
+      "type": "string",
+      "enum": [
+        "OAUTH",
+        "NO_AUTH"
+      ]
+    }
+  }
+}

--- a/schemas/agent-mcp-update.json
+++ b/schemas/agent-mcp-update.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/ApiCatalogMcpServerUpdateResult",
+  "definitions": {
+    "ApiCatalogMcpServerUpdateResult": {
+      "$ref": "#/definitions/McpServerOutput"
+    },
+    "McpServerOutput": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "type": {
+          "$ref": "#/definitions/McpServerType"
+        },
+        "status": {
+          "type": "string"
+        },
+        "serverUrl": {
+          "type": "string"
+        },
+        "authorization": {
+          "$ref": "#/definitions/McpServerAuthorizationOutput"
+        },
+        "createdById": {
+          "type": "string"
+        },
+        "createdDate": {
+          "type": "string"
+        },
+        "lastModifiedById": {
+          "type": "string"
+        },
+        "lastModifiedDate": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "type",
+        "status"
+      ],
+      "additionalProperties": false
+    },
+    "McpServerType": {
+      "type": "string",
+      "const": "EXTERNAL"
+    },
+    "McpServerAuthorizationOutput": {
+      "type": "object",
+      "properties": {
+        "authType": {
+          "$ref": "#/definitions/McpAuthType"
+        },
+        "identityProvider": {
+          "type": "string"
+        },
+        "scope": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "authType"
+      ],
+      "additionalProperties": false
+    },
+    "McpAuthType": {
+      "type": "string",
+      "enum": [
+        "OAUTH",
+        "NO_AUTH"
+      ]
+    }
+  }
+}

--- a/src/commands/agent/mcp/asset/list.ts
+++ b/src/commands/agent/mcp/asset/list.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
+import { Messages, SfError } from '@salesforce/core';
+import { ApiCatalog, type McpServerAssetCollection } from '@salesforce/agents';
+
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
+const messages = Messages.loadMessages('@salesforce/plugin-agent', 'agent.mcp.asset.list');
+
+export type ApiCatalogMcpServerAssetListResult = McpServerAssetCollection;
+
+export default class ApiCatalogMcpServerAssetList extends SfCommand<ApiCatalogMcpServerAssetListResult> {
+  public static readonly summary = messages.getMessage('summary');
+  public static readonly description = messages.getMessage('description');
+  public static readonly examples = messages.getMessages('examples');
+  public static readonly enableJsonFlag = true;
+  public static readonly state = 'preview';
+
+  public static readonly flags = {
+    'target-org': Flags.requiredOrg(),
+    'api-version': Flags.orgApiVersion(),
+    'mcp-server-id': Flags.string({
+      summary: messages.getMessage('flags.mcp-server-id.summary'),
+      char: 'i',
+      required: true,
+    }),
+  };
+
+  public async run(): Promise<ApiCatalogMcpServerAssetListResult> {
+    const { flags } = await this.parse(ApiCatalogMcpServerAssetList);
+    const connection = flags['target-org'].getConnection(flags['api-version']);
+
+    let result: McpServerAssetCollection;
+    try {
+      result = await ApiCatalog.listMcpServerAssets(connection, flags['mcp-server-id']);
+    } catch (error) {
+      const wrapped = SfError.wrap(error);
+      throw new SfError(
+        messages.getMessage('error.failed', [wrapped.message]),
+        'ListMcpServerAssetsFailed',
+        [],
+        4,
+        wrapped
+      );
+    }
+
+    if (!this.jsonEnabled()) {
+      this.table({
+        data: (result.assets ?? []).map((a) => ({
+          id: a.id,
+          name: a.name,
+          kind: a.kind,
+          active: a.active,
+          availableAsAgentAction: a.availableAsAgentAction,
+        })),
+        columns: [
+          { key: 'id', name: 'ID' },
+          { key: 'name', name: 'Name' },
+          { key: 'kind', name: 'Kind' },
+          { key: 'active', name: 'Active' },
+          { key: 'availableAsAgentAction', name: 'Agent Action' },
+        ],
+      });
+    }
+
+    return result;
+  }
+}

--- a/src/commands/agent/mcp/asset/replace.ts
+++ b/src/commands/agent/mcp/asset/replace.ts
@@ -43,10 +43,15 @@ export default class ApiCatalogMcpServerAssetReplace extends SfCommand<ApiCatalo
       char: 'i',
       required: true,
     }),
+    assets: Flags.string({
+      summary: messages.getMessage('flags.assets.summary'),
+      allowStdin: true,
+      exclusive: ['assets-file'],
+    }),
     'assets-file': Flags.file({
       summary: messages.getMessage('flags.assets-file.summary'),
-      required: true,
       exists: true,
+      exclusive: ['assets'],
     }),
   };
 
@@ -54,7 +59,13 @@ export default class ApiCatalogMcpServerAssetReplace extends SfCommand<ApiCatalo
     const { flags } = await this.parse(ApiCatalogMcpServerAssetReplace);
     const connection = flags['target-org'].getConnection(flags['api-version']);
 
-    const raw = readFileSync(flags['assets-file'], 'utf8');
+    // Accept the allowlist either inline (--assets '<json>' or --assets - for stdin) or
+    // from a file (--assets-file). Exactly one is required.
+    const raw = flags.assets ?? (flags['assets-file'] ? readFileSync(flags['assets-file'], 'utf8') : undefined);
+    if (raw === undefined) {
+      throw new SfError(messages.getMessage('error.noInput'), 'NoInput', [], 1);
+    }
+
     let parsed: unknown;
     try {
       parsed = JSON.parse(raw);

--- a/src/commands/agent/mcp/asset/replace.ts
+++ b/src/commands/agent/mcp/asset/replace.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { readFileSync } from 'node:fs';
+import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
+import { Messages, SfError } from '@salesforce/core';
+import {
+  ApiCatalog,
+  type McpServerAssetCollection,
+  type McpServerAssetReplaceInput,
+  type McpServerAssetReplaceItem,
+} from '@salesforce/agents';
+
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
+const messages = Messages.loadMessages('@salesforce/plugin-agent', 'agent.mcp.asset.replace');
+
+export type ApiCatalogMcpServerAssetReplaceResult = McpServerAssetCollection;
+
+export default class ApiCatalogMcpServerAssetReplace extends SfCommand<ApiCatalogMcpServerAssetReplaceResult> {
+  public static readonly summary = messages.getMessage('summary');
+  public static readonly description = messages.getMessage('description');
+  public static readonly examples = messages.getMessages('examples');
+  public static readonly enableJsonFlag = true;
+  public static readonly state = 'preview';
+
+  public static readonly flags = {
+    'target-org': Flags.requiredOrg(),
+    'api-version': Flags.orgApiVersion(),
+    'mcp-server-id': Flags.string({
+      summary: messages.getMessage('flags.mcp-server-id.summary'),
+      char: 'i',
+      required: true,
+    }),
+    'assets-file': Flags.file({
+      summary: messages.getMessage('flags.assets-file.summary'),
+      required: true,
+      exists: true,
+    }),
+  };
+
+  public async run(): Promise<ApiCatalogMcpServerAssetReplaceResult> {
+    const { flags } = await this.parse(ApiCatalogMcpServerAssetReplace);
+    const connection = flags['target-org'].getConnection(flags['api-version']);
+
+    const raw = readFileSync(flags['assets-file'], 'utf8');
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      throw new SfError(messages.getMessage('error.invalidJson'), 'InvalidJson', [], 1);
+    }
+
+    const assets = (
+      Array.isArray(parsed) ? parsed : (parsed as { assets?: McpServerAssetReplaceItem[] }).assets
+    ) as McpServerAssetReplaceItem[] | undefined;
+    if (!assets || !Array.isArray(assets)) {
+      throw new SfError(messages.getMessage('error.invalidShape'), 'InvalidShape', [], 1);
+    }
+
+    const input: McpServerAssetReplaceInput = { assets };
+
+    let result: McpServerAssetCollection;
+    try {
+      result = await ApiCatalog.replaceMcpServerAssets(connection, flags['mcp-server-id'], input);
+    } catch (error) {
+      const wrapped = SfError.wrap(error);
+      throw new SfError(
+        messages.getMessage('error.failed', [wrapped.message]),
+        'ReplaceMcpServerAssetsFailed',
+        [],
+        4,
+        wrapped
+      );
+    }
+
+    if (!this.jsonEnabled()) {
+      this.table({
+        data: (result.assets ?? []).map((a) => ({
+          id: a.id,
+          name: a.name,
+          kind: a.kind,
+          active: a.active,
+        })),
+        columns: [
+          { key: 'id', name: 'ID' },
+          { key: 'name', name: 'Name' },
+          { key: 'kind', name: 'Kind' },
+          { key: 'active', name: 'Active' },
+        ],
+      });
+    }
+
+    return result;
+  }
+}

--- a/src/commands/agent/mcp/create.ts
+++ b/src/commands/agent/mcp/create.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
+import { Messages, SfError } from '@salesforce/core';
+import {
+  ApiCatalog,
+  type McpServerCreateOutput,
+  type McpServerCreateInput,
+  type McpServerAuthorizationInput,
+  type McpAuthType,
+} from '@salesforce/agents';
+
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
+const messages = Messages.loadMessages('@salesforce/plugin-agent', 'agent.mcp.create');
+
+export type ApiCatalogMcpServerCreateResult = McpServerCreateOutput;
+
+export default class ApiCatalogMcpServerCreate extends SfCommand<McpServerCreateOutput> {
+  public static readonly summary = messages.getMessage('summary');
+  public static readonly description = messages.getMessage('description');
+  public static readonly examples = messages.getMessages('examples');
+  public static readonly enableJsonFlag = true;
+  public static readonly state = 'preview';
+
+  public static readonly flags = {
+    'target-org': Flags.requiredOrg(),
+    'api-version': Flags.orgApiVersion(),
+    name: Flags.string({
+      summary: messages.getMessage('flags.name.summary'),
+      char: 'n',
+      required: true,
+    }),
+    label: Flags.string({
+      summary: messages.getMessage('flags.label.summary'),
+    }),
+    description: Flags.string({
+      summary: messages.getMessage('flags.description.summary'),
+    }),
+    'server-url': Flags.string({
+      summary: messages.getMessage('flags.server-url.summary'),
+      required: true,
+    }),
+    'auth-type': Flags.option({
+      summary: messages.getMessage('flags.auth-type.summary'),
+      options: ['OAUTH', 'NO_AUTH'] as const,
+      default: 'NO_AUTH',
+    })(),
+    'identity-provider': Flags.string({
+      summary: messages.getMessage('flags.identity-provider.summary'),
+    }),
+    'client-id': Flags.string({
+      summary: messages.getMessage('flags.client-id.summary'),
+    }),
+    'client-secret': Flags.string({
+      summary: messages.getMessage('flags.client-secret.summary'),
+      allowStdin: true,
+    }),
+    scope: Flags.string({
+      summary: messages.getMessage('flags.scope.summary'),
+    }),
+  };
+
+  public async run(): Promise<McpServerCreateOutput> {
+    const { flags } = await this.parse(ApiCatalogMcpServerCreate);
+    const connection = flags['target-org'].getConnection(flags['api-version']);
+
+    const authType = flags['auth-type'] as McpAuthType;
+
+    if (authType === 'OAUTH') {
+      if (!flags['identity-provider'] || !flags['client-id'] || !flags['client-secret'] || !flags.scope) {
+        throw new SfError(messages.getMessage('error.missingOauthFields'), 'MissingOauthFields', [], 1);
+      }
+    }
+
+    const input: McpServerCreateInput = {
+      name: flags.name,
+      type: 'EXTERNAL',
+      serverUrl: flags['server-url'],
+    };
+
+    if (flags.label) {
+      input.label = flags.label;
+    }
+
+    if (flags.description) {
+      input.description = flags.description;
+    }
+
+    if (authType === 'OAUTH') {
+      const authorization: McpServerAuthorizationInput = {
+        authType: 'OAUTH',
+        identityProvider: flags['identity-provider']!,
+        clientId: flags['client-id']!,
+        clientSecret: flags['client-secret']!,
+        scope: flags.scope!,
+      };
+      input.authorization = authorization;
+    } else {
+      input.authorization = { authType: 'NO_AUTH' };
+    }
+
+    let result: McpServerCreateOutput;
+    try {
+      result = await ApiCatalog.createMcpServer(connection, input);
+    } catch (error) {
+      const wrapped = SfError.wrap(error);
+      throw new SfError(
+        messages.getMessage('error.failed', [wrapped.message]),
+        'CreateMcpServerFailed',
+        [],
+        4,
+        wrapped
+      );
+    }
+
+    if (!this.jsonEnabled()) {
+      this.log(`Created MCP server "${result.server.name}" (${result.server.id}).`);
+      this.log(`Discovered ${result.assets.length} asset(s).`);
+    }
+
+    return result;
+  }
+}

--- a/src/commands/agent/mcp/delete.ts
+++ b/src/commands/agent/mcp/delete.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
+import { Messages, SfError } from '@salesforce/core';
+import { ApiCatalog } from '@salesforce/agents';
+
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
+const messages = Messages.loadMessages('@salesforce/plugin-agent', 'agent.mcp.delete');
+
+export type ApiCatalogMcpServerDeleteResult = { id: string; deleted: boolean };
+
+export default class ApiCatalogMcpServerDelete extends SfCommand<ApiCatalogMcpServerDeleteResult> {
+  public static readonly summary = messages.getMessage('summary');
+  public static readonly description = messages.getMessage('description');
+  public static readonly examples = messages.getMessages('examples');
+  public static readonly enableJsonFlag = true;
+  public static readonly state = 'preview';
+
+  public static readonly flags = {
+    'target-org': Flags.requiredOrg(),
+    'api-version': Flags.orgApiVersion(),
+    'mcp-server-id': Flags.string({
+      summary: messages.getMessage('flags.mcp-server-id.summary'),
+      char: 'i',
+      required: true,
+    }),
+    'no-prompt': Flags.boolean({
+      summary: messages.getMessage('flags.no-prompt.summary'),
+      default: false,
+    }),
+  };
+
+  public async run(): Promise<ApiCatalogMcpServerDeleteResult> {
+    const { flags } = await this.parse(ApiCatalogMcpServerDelete);
+    const connection = flags['target-org'].getConnection(flags['api-version']);
+
+    // Skip the confirmation prompt in JSON mode — scripted/CI callers cannot answer it.
+    if (!flags['no-prompt'] && !this.jsonEnabled()) {
+      const confirmed = await this.confirm({
+        message: messages.getMessage('confirm.delete', [flags['mcp-server-id']]),
+      });
+      if (!confirmed) {
+        throw new SfError(messages.getMessage('error.aborted'), 'Aborted', [], 1);
+      }
+    }
+
+    try {
+      await ApiCatalog.deleteMcpServer(connection, flags['mcp-server-id']);
+    } catch (error) {
+      const wrapped = SfError.wrap(error);
+      throw new SfError(
+        messages.getMessage('error.failed', [wrapped.message]),
+        'DeleteMcpServerFailed',
+        [],
+        4,
+        wrapped
+      );
+    }
+
+    if (!this.jsonEnabled()) {
+      this.log(`Deleted MCP server ${flags['mcp-server-id']}.`);
+    }
+
+    return { id: flags['mcp-server-id'], deleted: true };
+  }
+}

--- a/src/commands/agent/mcp/fetch.ts
+++ b/src/commands/agent/mcp/fetch.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
+import { Messages, SfError } from '@salesforce/core';
+import { ApiCatalog, type McpServerFetchOutput } from '@salesforce/agents';
+
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
+const messages = Messages.loadMessages('@salesforce/plugin-agent', 'agent.mcp.fetch');
+
+export type ApiCatalogMcpServerFetchResult = McpServerFetchOutput;
+
+export default class ApiCatalogMcpServerFetch extends SfCommand<ApiCatalogMcpServerFetchResult> {
+  public static readonly summary = messages.getMessage('summary');
+  public static readonly description = messages.getMessage('description');
+  public static readonly examples = messages.getMessages('examples');
+  public static readonly enableJsonFlag = true;
+  public static readonly state = 'preview';
+
+  public static readonly flags = {
+    'target-org': Flags.requiredOrg(),
+    'api-version': Flags.orgApiVersion(),
+    'mcp-server-id': Flags.string({
+      summary: messages.getMessage('flags.mcp-server-id.summary'),
+      char: 'i',
+      required: true,
+    }),
+  };
+
+  public async run(): Promise<ApiCatalogMcpServerFetchResult> {
+    const { flags } = await this.parse(ApiCatalogMcpServerFetch);
+    const connection = flags['target-org'].getConnection(flags['api-version']);
+
+    let result: McpServerFetchOutput;
+    try {
+      result = await ApiCatalog.fetchMcpServer(connection, flags['mcp-server-id']);
+    } catch (error) {
+      const wrapped = SfError.wrap(error);
+      throw new SfError(
+        messages.getMessage('error.failed', [wrapped.message]),
+        'FetchMcpServerFailed',
+        [],
+        4,
+        wrapped
+      );
+    }
+
+    if (!this.jsonEnabled()) {
+      this.table({
+        data: (result.assets ?? []).map((a) => ({
+          name: a.name,
+          kind: a.kind,
+          status: a.status,
+          active: a.active,
+          availableAsAgentAction: a.availableAsAgentAction,
+        })),
+        columns: [
+          { key: 'name', name: 'Name' },
+          { key: 'kind', name: 'Kind' },
+          { key: 'status', name: 'Status' },
+          { key: 'active', name: 'Active' },
+          { key: 'availableAsAgentAction', name: 'Agent Action' },
+        ],
+      });
+    }
+
+    return result;
+  }
+}

--- a/src/commands/agent/mcp/get.ts
+++ b/src/commands/agent/mcp/get.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
+import { Messages, SfError } from '@salesforce/core';
+import { ApiCatalog, type McpServerOutput } from '@salesforce/agents';
+
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
+const messages = Messages.loadMessages('@salesforce/plugin-agent', 'agent.mcp.get');
+
+export type ApiCatalogMcpServerGetResult = McpServerOutput;
+
+export default class ApiCatalogMcpServerGet extends SfCommand<ApiCatalogMcpServerGetResult> {
+  public static readonly summary = messages.getMessage('summary');
+  public static readonly description = messages.getMessage('description');
+  public static readonly examples = messages.getMessages('examples');
+  public static readonly enableJsonFlag = true;
+  public static readonly state = 'preview';
+
+  public static readonly flags = {
+    'target-org': Flags.requiredOrg(),
+    'api-version': Flags.orgApiVersion(),
+    'mcp-server-id': Flags.string({
+      summary: messages.getMessage('flags.mcp-server-id.summary'),
+      char: 'i',
+      required: true,
+    }),
+  };
+
+  public async run(): Promise<ApiCatalogMcpServerGetResult> {
+    const { flags } = await this.parse(ApiCatalogMcpServerGet);
+    const connection = flags['target-org'].getConnection(flags['api-version']);
+
+    let result: McpServerOutput;
+    try {
+      result = await ApiCatalog.getMcpServer(connection, flags['mcp-server-id']);
+    } catch (error) {
+      const wrapped = SfError.wrap(error);
+      throw new SfError(
+        messages.getMessage('error.failed', [wrapped.message]),
+        'GetMcpServerFailed',
+        [],
+        4,
+        wrapped
+      );
+    }
+
+    if (!this.jsonEnabled()) {
+      this.log(`Id:        ${result.id}`);
+      this.log(`Name:      ${result.name}`);
+      this.log(`Label:     ${result.label ?? ''}`);
+      this.log(`Type:      ${result.type}`);
+      this.log(`Status:    ${result.status}`);
+      this.log(`Server URL: ${result.serverUrl ?? ''}`);
+    }
+
+    return result;
+  }
+}

--- a/src/commands/agent/mcp/list.ts
+++ b/src/commands/agent/mcp/list.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
+import { Messages, SfError } from '@salesforce/core';
+import { ApiCatalog, type McpServerCollection } from '@salesforce/agents';
+
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
+const messages = Messages.loadMessages('@salesforce/plugin-agent', 'agent.mcp.list');
+
+export type ApiCatalogMcpServerListResult = McpServerCollection;
+
+export default class ApiCatalogMcpServerList extends SfCommand<ApiCatalogMcpServerListResult> {
+  public static readonly summary = messages.getMessage('summary');
+  public static readonly description = messages.getMessage('description');
+  public static readonly examples = messages.getMessages('examples');
+  public static readonly enableJsonFlag = true;
+  public static readonly state = 'preview';
+
+  public static readonly flags = {
+    'target-org': Flags.requiredOrg(),
+    'api-version': Flags.orgApiVersion(),
+    label: Flags.string({
+      summary: messages.getMessage('flags.label.summary'),
+    }),
+    type: Flags.option({
+      summary: messages.getMessage('flags.type.summary'),
+      options: ['EXTERNAL'] as const,
+    })(),
+    status: Flags.option({
+      summary: messages.getMessage('flags.status.summary'),
+      options: ['ACTIVE', 'DISCONNECTED'] as const,
+    })(),
+  };
+
+  public async run(): Promise<ApiCatalogMcpServerListResult> {
+    const { flags } = await this.parse(ApiCatalogMcpServerList);
+    const connection = flags['target-org'].getConnection(flags['api-version']);
+
+    let result: McpServerCollection;
+    try {
+      result = await ApiCatalog.listMcpServers(connection, {
+        label: flags.label,
+        type: flags.type,
+        status: flags.status,
+      });
+    } catch (error) {
+      const wrapped = SfError.wrap(error);
+      throw new SfError(
+        messages.getMessage('error.failed', [wrapped.message]),
+        'ListMcpServersFailed',
+        [],
+        4,
+        wrapped
+      );
+    }
+
+    if (!this.jsonEnabled()) {
+      this.table({
+        data: result.mcpServers ?? [],
+        columns: [
+          { key: 'id', name: 'ID' },
+          { key: 'name', name: 'Name' },
+          { key: 'label', name: 'Label' },
+          { key: 'type', name: 'Type' },
+          { key: 'status', name: 'Status' },
+          { key: 'serverUrl', name: 'Server URL' },
+        ],
+      });
+    }
+
+    return result;
+  }
+}

--- a/src/commands/agent/mcp/update.ts
+++ b/src/commands/agent/mcp/update.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
+import { Messages, SfError } from '@salesforce/core';
+import {
+  ApiCatalog,
+  type McpServerOutput,
+  type McpServerUpdateInput,
+  type McpServerAuthorizationInput,
+  type McpAuthType,
+} from '@salesforce/agents';
+
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
+const messages = Messages.loadMessages('@salesforce/plugin-agent', 'agent.mcp.update');
+
+export type ApiCatalogMcpServerUpdateResult = McpServerOutput;
+
+export default class ApiCatalogMcpServerUpdate extends SfCommand<ApiCatalogMcpServerUpdateResult> {
+  public static readonly summary = messages.getMessage('summary');
+  public static readonly description = messages.getMessage('description');
+  public static readonly examples = messages.getMessages('examples');
+  public static readonly enableJsonFlag = true;
+  public static readonly state = 'preview';
+
+  public static readonly flags = {
+    'target-org': Flags.requiredOrg(),
+    'api-version': Flags.orgApiVersion(),
+    'mcp-server-id': Flags.string({
+      summary: messages.getMessage('flags.mcp-server-id.summary'),
+      char: 'i',
+      required: true,
+    }),
+    label: Flags.string({
+      summary: messages.getMessage('flags.label.summary'),
+    }),
+    description: Flags.string({
+      summary: messages.getMessage('flags.description.summary'),
+    }),
+    'server-url': Flags.string({
+      summary: messages.getMessage('flags.server-url.summary'),
+    }),
+    'auth-type': Flags.option({
+      summary: messages.getMessage('flags.auth-type.summary'),
+      options: ['OAUTH', 'NO_AUTH'] as const,
+    })(),
+    'identity-provider': Flags.string({
+      summary: messages.getMessage('flags.identity-provider.summary'),
+    }),
+    'client-id': Flags.string({
+      summary: messages.getMessage('flags.client-id.summary'),
+    }),
+    'client-secret': Flags.string({
+      summary: messages.getMessage('flags.client-secret.summary'),
+      allowStdin: true,
+    }),
+    scope: Flags.string({
+      summary: messages.getMessage('flags.scope.summary'),
+    }),
+  };
+
+  public async run(): Promise<ApiCatalogMcpServerUpdateResult> {
+    const { flags } = await this.parse(ApiCatalogMcpServerUpdate);
+    const connection = flags['target-org'].getConnection(flags['api-version']);
+
+    const input: McpServerUpdateInput = {};
+
+    if (flags.label !== undefined) {
+      input.label = flags.label;
+    }
+
+    if (flags.description !== undefined) {
+      input.description = flags.description;
+    }
+
+    if (flags['server-url'] !== undefined) {
+      input.serverUrl = flags['server-url'];
+    }
+
+    const authType = flags['auth-type'] as McpAuthType | undefined;
+
+    if (authType) {
+      if (authType === 'OAUTH') {
+        if (
+          !flags['identity-provider'] ||
+          !flags['client-id'] ||
+          !flags['client-secret'] ||
+          !flags.scope
+        ) {
+          throw new SfError(messages.getMessage('error.missingOauthFields'), 'MissingOauthFields', [], 1);
+        }
+
+        const authorization: McpServerAuthorizationInput = {
+          authType: 'OAUTH',
+          identityProvider: flags['identity-provider'],
+          clientId: flags['client-id'],
+          clientSecret: flags['client-secret'],
+          scope: flags.scope,
+        };
+        input.authorization = authorization;
+      } else {
+        const authorization: McpServerAuthorizationInput = { authType: 'NO_AUTH' };
+        input.authorization = authorization;
+      }
+    }
+
+    if (Object.keys(input).length === 0) {
+      throw new SfError(messages.getMessage('error.noFields'), 'NoFields', [], 1);
+    }
+
+    let result: McpServerOutput;
+    try {
+      result = await ApiCatalog.updateMcpServer(connection, flags['mcp-server-id'], input);
+    } catch (error) {
+      const wrapped = SfError.wrap(error);
+      throw new SfError(
+        messages.getMessage('error.failed', [wrapped.message]),
+        'UpdateMcpServerFailed',
+        [],
+        4,
+        wrapped
+      );
+    }
+
+    if (!this.jsonEnabled()) {
+      this.log(`Updated MCP server "${result.label ?? result.name}" (${result.id}).`);
+    }
+
+    return result;
+  }
+}

--- a/test/commands/agent/mcp/mcp.test.ts
+++ b/test/commands/agent/mcp/mcp.test.ts
@@ -1,0 +1,361 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-return */
+
+import { writeFileSync, mkdtempSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { expect } from 'chai';
+import { TestContext, MockTestOrgData } from '@salesforce/core/testSetup';
+import { stubSfCommandUx } from '@salesforce/sf-plugins-core';
+import AgentMcpList from '../../../../src/commands/agent/mcp/list.js';
+import AgentMcpCreate from '../../../../src/commands/agent/mcp/create.js';
+import AgentMcpGet from '../../../../src/commands/agent/mcp/get.js';
+import AgentMcpUpdate from '../../../../src/commands/agent/mcp/update.js';
+import AgentMcpDelete from '../../../../src/commands/agent/mcp/delete.js';
+import AgentMcpFetch from '../../../../src/commands/agent/mcp/fetch.js';
+import AgentMcpAssetList from '../../../../src/commands/agent/mcp/asset/list.js';
+import AgentMcpAssetReplace from '../../../../src/commands/agent/mcp/asset/replace.js';
+
+describe('agent mcp commands', () => {
+  const $$ = new TestContext();
+
+  beforeEach(() => {
+    stubSfCommandUx($$.SANDBOX);
+  });
+
+  afterEach(() => {
+    $$.restore();
+  });
+
+  it('list forwards --label, --type and --status as query params', async () => {
+    const testOrg = new MockTestOrgData();
+    await $$.stubAuths(testOrg);
+    let capturedUrl: string | undefined;
+    $$.fakeConnectionRequest = (req: any) => {
+      capturedUrl = req.url as string;
+      return Promise.resolve({ mcpServers: [] });
+    };
+
+    await AgentMcpList.run([
+      '--target-org',
+      testOrg.username,
+      '--label',
+      'foo',
+      '--type',
+      'EXTERNAL',
+      '--status',
+      'ACTIVE',
+    ]);
+
+    expect(capturedUrl).to.include('label=foo');
+    expect(capturedUrl).to.include('type=EXTERNAL');
+    expect(capturedUrl).to.include('status=ACTIVE');
+  });
+
+  it('create builds the EXTERNAL/NO_AUTH body and surfaces the auto-fetched assets', async () => {
+    const testOrg = new MockTestOrgData();
+    await $$.stubAuths(testOrg);
+    let captured: any;
+    // The server registration triggers a live auto-fetch of remote assets; we mock that
+    // response in-process (the same way the ADL tests mock their external S3/indexing calls)
+    // so the test is deterministic and never touches a real MCP endpoint.
+    $$.fakeConnectionRequest = (req: any) => {
+      captured = req;
+      return Promise.resolve({
+        server: { id: '0XS1', name: 'my-server', type: 'EXTERNAL', status: 'ACTIVE' },
+        assets: [
+          { name: 'McpTool__add', kind: 'MCP_TOOL', active: false },
+          { name: 'McpTool__squareRoot', kind: 'MCP_TOOL', active: false },
+        ],
+      });
+    };
+
+    const result = await AgentMcpCreate.run([
+      '--target-org',
+      testOrg.username,
+      '--name',
+      'my-server',
+      '--server-url',
+      'https://example.com/mcp',
+    ]);
+
+    expect(captured.method).to.equal('POST');
+    expect(captured.url).to.match(/\/api-catalog\/mcp-servers$/);
+    const body = JSON.parse(captured.body as string);
+    expect(body).to.deep.include({ name: 'my-server', type: 'EXTERNAL', serverUrl: 'https://example.com/mcp' });
+    expect(body.authorization).to.deep.equal({ authType: 'NO_AUTH' });
+    expect(result.server.id).to.equal('0XS1');
+    expect(result.server.status).to.equal('ACTIVE');
+    expect(result.assets.map((a) => a.name)).to.deep.equal(['McpTool__add', 'McpTool__squareRoot']);
+  });
+
+  it('create builds the OAUTH authorization body from the flags', async () => {
+    const testOrg = new MockTestOrgData();
+    await $$.stubAuths(testOrg);
+    let captured: any;
+    $$.fakeConnectionRequest = (req: any) => {
+      captured = req;
+      return Promise.resolve({
+        server: { id: '0XS2', name: 'oauth-server', type: 'EXTERNAL', status: 'ACTIVE' },
+        assets: [],
+      });
+    };
+
+    await AgentMcpCreate.run([
+      '--target-org',
+      testOrg.username,
+      '--name',
+      'oauth-server',
+      '--server-url',
+      'https://example.com/mcp',
+      '--auth-type',
+      'OAUTH',
+      '--identity-provider',
+      'https://idp.example.com/token',
+      '--client-id',
+      'abc123',
+      '--client-secret',
+      's3cr3t',
+      '--scope',
+      'read write',
+    ]);
+
+    const body = JSON.parse(captured.body as string);
+    expect(body.authorization).to.deep.equal({
+      authType: 'OAUTH',
+      identityProvider: 'https://idp.example.com/token',
+      clientId: 'abc123',
+      clientSecret: 's3cr3t',
+      scope: 'read write',
+    });
+  });
+
+  it('create rejects OAUTH without the required fields', async () => {
+    const testOrg = new MockTestOrgData();
+    await $$.stubAuths(testOrg);
+    $$.fakeConnectionRequest = () => Promise.resolve({} as any);
+
+    try {
+      await AgentMcpCreate.run([
+        '--target-org',
+        testOrg.username,
+        '--name',
+        'my-server',
+        '--server-url',
+        'https://example.com/mcp',
+        '--auth-type',
+        'OAUTH',
+      ]);
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect((err as { name: string }).name).to.equal('MissingOauthFields');
+    }
+  });
+
+  it('delete with --no-prompt DELETEs without confirmation', async () => {
+    const testOrg = new MockTestOrgData();
+    await $$.stubAuths(testOrg);
+    let captured: any;
+    $$.fakeConnectionRequest = (req: any) => {
+      captured = req;
+      return Promise.resolve(undefined as any);
+    };
+
+    const result = await AgentMcpDelete.run([
+      '--target-org',
+      testOrg.username,
+      '--mcp-server-id',
+      '0XS1',
+      '--no-prompt',
+    ]);
+
+    expect(captured.method).to.equal('DELETE');
+    expect(captured.url).to.match(/\/mcp-servers\/0XS1$/);
+    expect(result).to.deep.equal({ id: '0XS1', deleted: true });
+  });
+
+  it('delete skips the prompt in --json mode (no --no-prompt)', async () => {
+    const testOrg = new MockTestOrgData();
+    await $$.stubAuths(testOrg);
+    let captured: any;
+    $$.fakeConnectionRequest = (req: any) => {
+      captured = req;
+      return Promise.resolve(undefined as any);
+    };
+
+    // No --no-prompt, but --json: must NOT block on a prompt.
+    const result = await AgentMcpDelete.run(['--target-org', testOrg.username, '--mcp-server-id', '0XS1', '--json']);
+
+    expect(captured.method).to.equal('DELETE');
+    expect(result).to.deep.equal({ id: '0XS1', deleted: true });
+  });
+
+  it('update builds a partial PATCH-style body and PUTs it', async () => {
+    const testOrg = new MockTestOrgData();
+    await $$.stubAuths(testOrg);
+    let captured: any;
+    $$.fakeConnectionRequest = (req: any) => {
+      captured = req;
+      return Promise.resolve({ id: '0XS1', name: 'n', type: 'EXTERNAL', status: 'ACTIVE' });
+    };
+
+    await AgentMcpUpdate.run(['--target-org', testOrg.username, '--mcp-server-id', '0XS1', '--label', 'New label']);
+
+    expect(captured.method).to.equal('PUT');
+    expect(captured.url).to.match(/\/mcp-servers\/0XS1$/);
+    const body = JSON.parse(captured.body as string);
+    expect(body).to.deep.equal({ label: 'New label' });
+  });
+
+  it('update throws NoFields when nothing is provided', async () => {
+    const testOrg = new MockTestOrgData();
+    await $$.stubAuths(testOrg);
+    $$.fakeConnectionRequest = () => Promise.resolve({} as any);
+
+    try {
+      await AgentMcpUpdate.run(['--target-org', testOrg.username, '--mcp-server-id', '0XS1']);
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect((err as { name: string }).name).to.equal('NoFields');
+    }
+  });
+
+  it('asset replace reads an array-shaped JSON file and PUTs the allowlist', async () => {
+    const testOrg = new MockTestOrgData();
+    await $$.stubAuths(testOrg);
+    const dir = mkdtempSync(join(tmpdir(), 'mcp-'));
+    const file = join(dir, 'assets.json');
+    writeFileSync(file, JSON.stringify([{ name: 'tool-a', active: true }]));
+
+    let captured: any;
+    $$.fakeConnectionRequest = (req: any) => {
+      captured = req;
+      return Promise.resolve({ assets: [{ id: '1', name: 'tool-a', kind: 'MCP_TOOL', active: true }] });
+    };
+
+    await AgentMcpAssetReplace.run([
+      '--target-org',
+      testOrg.username,
+      '--mcp-server-id',
+      '0XS1',
+      '--assets-file',
+      file,
+    ]);
+
+    expect(captured.method).to.equal('PUT');
+    expect(captured.url).to.match(/\/mcp-servers\/0XS1\/assets$/);
+    expect(JSON.parse(captured.body as string).assets[0].name).to.equal('tool-a');
+  });
+
+  it('asset replace accepts the {assets:[]} object shape', async () => {
+    const testOrg = new MockTestOrgData();
+    await $$.stubAuths(testOrg);
+    const dir = mkdtempSync(join(tmpdir(), 'mcp-'));
+    const file = join(dir, 'assets.json');
+    writeFileSync(file, JSON.stringify({ assets: [{ name: 'tool-b' }] }));
+
+    let captured: any;
+    $$.fakeConnectionRequest = (req: any) => {
+      captured = req;
+      return Promise.resolve({ assets: [] });
+    };
+
+    await AgentMcpAssetReplace.run(['--target-org', testOrg.username, '--mcp-server-id', '0XS1', '--assets-file', file]);
+
+    expect(JSON.parse(captured.body as string).assets[0].name).to.equal('tool-b');
+  });
+
+  it('asset replace throws InvalidShape for a non-asset JSON file', async () => {
+    const testOrg = new MockTestOrgData();
+    await $$.stubAuths(testOrg);
+    const dir = mkdtempSync(join(tmpdir(), 'mcp-'));
+    const file = join(dir, 'bad.json');
+    writeFileSync(file, JSON.stringify({ nope: true }));
+    $$.fakeConnectionRequest = () => Promise.resolve({} as any);
+
+    try {
+      await AgentMcpAssetReplace.run(['--target-org', testOrg.username, '--mcp-server-id', '0XS1', '--assets-file', file]);
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect((err as { name: string }).name).to.equal('InvalidShape');
+    }
+  });
+
+  it('get returns the server and strips the secret on read', async () => {
+    const testOrg = new MockTestOrgData();
+    await $$.stubAuths(testOrg);
+    let captured: any;
+    $$.fakeConnectionRequest = (req: any) => {
+      captured = req;
+      return Promise.resolve({
+        id: '0XS1',
+        name: 'my-server',
+        type: 'EXTERNAL',
+        status: 'ACTIVE',
+        // Connect API strips clientSecret on read; only non-sensitive auth metadata comes back.
+        authorization: { authType: 'OAUTH', identityProvider: 'https://idp.example.com/token', scope: 'read' },
+      });
+    };
+
+    const result = await AgentMcpGet.run(['--target-org', testOrg.username, '--mcp-server-id', '0XS1']);
+
+    expect(captured.method).to.equal('GET');
+    expect(captured.url).to.match(/\/mcp-servers\/0XS1$/);
+    expect(result.authorization?.authType).to.equal('OAUTH');
+    expect(result.authorization).to.not.have.property('clientSecret');
+  });
+
+  it('fetch POSTs to /fetch and returns the merged asset view (mocked, no live endpoint)', async () => {
+    const testOrg = new MockTestOrgData();
+    await $$.stubAuths(testOrg);
+    let captured: any;
+    // The real /fetch contacts the remote MCP server live; here we mock it so the test is
+    // deterministic and cannot hang against a sleepy external server.
+    $$.fakeConnectionRequest = (req: any) => {
+      captured = req;
+      return Promise.resolve({
+        assets: [
+          { name: 'McpTool__add', kind: 'MCP_TOOL', status: 'IN_SYNC' },
+          { name: 'McpTool__newTool', kind: 'MCP_TOOL', status: 'NOT_REGISTERED' },
+        ],
+      });
+    };
+
+    const result = await AgentMcpFetch.run(['--target-org', testOrg.username, '--mcp-server-id', '0XS1']);
+
+    expect(captured.method).to.equal('POST');
+    expect(captured.url).to.match(/\/mcp-servers\/0XS1\/fetch$/);
+    expect(result.assets.map((a) => a.name)).to.include('McpTool__newTool');
+  });
+
+  it('asset list GETs the allowlist', async () => {
+    const testOrg = new MockTestOrgData();
+    await $$.stubAuths(testOrg);
+    let captured: any;
+    $$.fakeConnectionRequest = (req: any) => {
+      captured = req;
+      return Promise.resolve({ assets: [{ id: '1', name: 'McpTool__add', kind: 'MCP_TOOL', active: true }] });
+    };
+
+    const result = await AgentMcpAssetList.run(['--target-org', testOrg.username, '--mcp-server-id', '0XS1']);
+
+    expect(captured.method).to.equal('GET');
+    expect(captured.url).to.match(/\/mcp-servers\/0XS1\/assets$/);
+    expect(result.assets[0].name).to.equal('McpTool__add');
+  });
+});

--- a/test/commands/agent/mcp/mcp.test.ts
+++ b/test/commands/agent/mcp/mcp.test.ts
@@ -280,6 +280,55 @@ describe('agent mcp commands', () => {
     expect(JSON.parse(captured.body as string).assets[0].name).to.equal('tool-b');
   });
 
+  it('asset replace accepts the allowlist inline via --assets', async () => {
+    const testOrg = new MockTestOrgData();
+    await $$.stubAuths(testOrg);
+    let captured: any;
+    $$.fakeConnectionRequest = (req: any) => {
+      captured = req;
+      return Promise.resolve({ assets: [{ id: '1', name: 'tool-inline', kind: 'MCP_TOOL', active: true }] });
+    };
+
+    await AgentMcpAssetReplace.run([
+      '--target-org',
+      testOrg.username,
+      '--mcp-server-id',
+      '0XS1',
+      '--assets',
+      '{"assets":[{"name":"tool-inline","active":true}]}',
+    ]);
+
+    expect(captured.method).to.equal('PUT');
+    expect(captured.url).to.match(/\/mcp-servers\/0XS1\/assets$/);
+    expect(JSON.parse(captured.body as string).assets[0].name).to.equal('tool-inline');
+  });
+
+  it('asset replace rejects passing both --assets and --assets-file', async () => {
+    const testOrg = new MockTestOrgData();
+    await $$.stubAuths(testOrg);
+    const dir = mkdtempSync(join(tmpdir(), 'mcp-'));
+    const file = join(dir, 'assets.json');
+    writeFileSync(file, JSON.stringify({ assets: [] }));
+    $$.fakeConnectionRequest = () => Promise.resolve({ assets: [] } as any);
+
+    try {
+      await AgentMcpAssetReplace.run([
+        '--target-org',
+        testOrg.username,
+        '--mcp-server-id',
+        '0XS1',
+        '--assets',
+        '{"assets":[]}',
+        '--assets-file',
+        file,
+      ]);
+      expect.fail('should have thrown');
+    } catch (err) {
+      // oclif raises a mutually-exclusive flags error before run() executes.
+      expect((err as Error).message).to.match(/cannot also be provided|exclusive/i);
+    }
+  });
+
   it('asset replace throws InvalidShape for a non-asset JSON file', async () => {
     const testOrg = new MockTestOrgData();
     await $$.stubAuths(testOrg);

--- a/test/nuts/agent.mcp.nut.ts
+++ b/test/nuts/agent.mcp.nut.ts
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { join } from 'node:path';
+import { writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { expect } from 'chai';
+import { execCmd } from '@salesforce/cli-plugins-testkit';
+
+/* eslint-disable no-console */
+
+// agent mcp NUTs — full MCP server ABM (create → get → update → asset allowlist →
+// delete) against a real org that has API Catalog enabled.
+//
+// Requires a pre-authenticated org. The smoke + NoAuth suites need only the org +
+// a reachable NoAuth MCP server. The OAuth suite additionally needs a reachable
+// MCP server + IDP, supplied via env vars (otherwise it is skipped).
+//
+// Usage:
+//   TARGET_ORG=apicat yarn test:nuts --grep "agent mcp"
+//
+//   # to run the NoAuth MCP lifecycle, point at a reachable MCP server:
+//   TARGET_ORG=apicat \
+//   MCP_NOAUTH_URL=https://mcptest-daniel-e6e72a8eba7a.herokuapp.com/mcp \
+//   yarn test:nuts --grep "agent mcp"
+//
+//   # to run the OAuth MCP lifecycle, supply all four OAuth values:
+//   TARGET_ORG=apicat \
+//   MCP_OAUTH_URL=https://protectedmcpserverhtt-nu000s.sjojp2.usa-w1.cloudhub.io/mcp \
+//   MCP_OAUTH_IDP=https://trial-8295331.okta.com/oauth2/default/v1/token \
+//   MCP_OAUTH_CLIENT_ID=0oasms6rj9YJqsqMU697 \
+//   MCP_OAUTH_CLIENT_SECRET=<secret> \
+//   MCP_OAUTH_SCOPE=read \
+//   yarn test:nuts --grep "agent mcp"
+
+const targetOrg = process.env.TARGET_ORG ?? process.env.TESTKIT_ORG_USERNAME;
+
+type Asset = { name: string; kind: string; active: boolean; availableAsAgentAction?: boolean };
+type McpServer = { id: string; name: string; label?: string; description?: string; status: string; serverUrl?: string };
+
+// ═══════════════════════════════════════════════════════════════
+// Smoke — list + typed not-found error (org only)
+// ═══════════════════════════════════════════════════════════════
+describe('agent mcp smoke NUTs', function () {
+  this.timeout(5 * 60 * 1000);
+
+  before(function skipIfNoOrg() {
+    if (!targetOrg) {
+      console.log('Skipping agent mcp NUTs: set TARGET_ORG or TESTKIT_ORG_USERNAME env var');
+      this.skip();
+    }
+  });
+
+  it('lists MCP servers', () => {
+    const result = execCmd<{ mcpServers: McpServer[] }>(`agent mcp list --target-org ${targetOrg} --json`, {
+      ensureExitCode: 0,
+    });
+    expect(result.jsonOutput!.result).to.have.property('mcpServers');
+  });
+
+  it('returns a typed error for a non-existent MCP server', () => {
+    const result = execCmd(`agent mcp get --mcp-server-id 0LeDOESNOTEXIST --target-org ${targetOrg} --json`);
+    expect(result.jsonOutput?.status).to.not.equal(0);
+    expect(result.jsonOutput?.name).to.equal('GetMcpServerFailed');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// MCP server ABM — NoAuth (create → get → update → assets → delete)
+// ═══════════════════════════════════════════════════════════════
+describe('agent mcp NoAuth ABM NUTs', function () {
+  this.timeout(10 * 60 * 1000);
+
+  const noAuthUrl = process.env.MCP_NOAUTH_URL;
+  let serverId = '';
+  let discoveredAssets: Asset[] = [];
+
+  before(function skipIfNoConfig() {
+    if (!targetOrg) this.skip();
+    if (!noAuthUrl) {
+      console.log('Skipping NoAuth MCP ABM: set MCP_NOAUTH_URL to a reachable MCP server');
+      this.skip();
+    }
+  });
+
+  after('best-effort cleanup', () => {
+    if (serverId) {
+      execCmd(`agent mcp delete --mcp-server-id ${serverId} --no-prompt --target-org ${targetOrg} --json`);
+    }
+  });
+
+  it('creates a NoAuth MCP server (auto-fetches assets)', () => {
+    const name = `nutNoAuth${Date.now()}`;
+    const result = execCmd<{ server: McpServer; assets: Asset[] }>(
+      `agent mcp create --name "${name}" --server-url "${noAuthUrl}" --target-org ${targetOrg} --json`,
+      { ensureExitCode: 0 }
+    );
+    const { server, assets } = result.jsonOutput!.result;
+    expect(server).to.have.property('id');
+    expect(server.status).to.equal('ACTIVE');
+    expect(assets).to.be.an('array');
+    serverId = server.id;
+    discoveredAssets = assets;
+    console.log(`Created NoAuth MCP server ${serverId} with ${assets.length} discovered assets`);
+  });
+
+  it('gets the created server', () => {
+    const result = execCmd<McpServer>(
+      `agent mcp get --mcp-server-id ${serverId} --target-org ${targetOrg} --json`,
+      { ensureExitCode: 0 }
+    );
+    expect(result.jsonOutput!.result.id).to.equal(serverId);
+    expect(result.jsonOutput!.result.serverUrl).to.equal(noAuthUrl);
+  });
+
+  it('appears in the list', () => {
+    const result = execCmd<{ mcpServers: McpServer[] }>(`agent mcp list --target-org ${targetOrg} --json`, {
+      ensureExitCode: 0,
+    });
+    expect(result.jsonOutput!.result.mcpServers.some((s) => s.id === serverId)).to.be.true;
+  });
+
+  it('updates the description', () => {
+    const result = execCmd<McpServer>(
+      `agent mcp update --mcp-server-id ${serverId} --description "Updated by NUT" --target-org ${targetOrg} --json`,
+      { ensureExitCode: 0 }
+    );
+    expect(result.jsonOutput!.result.description).to.equal('Updated by NUT');
+  });
+
+  it('rejects an update with no fields', () => {
+    const result = execCmd(`agent mcp update --mcp-server-id ${serverId} --target-org ${targetOrg} --json`);
+    expect(result.jsonOutput?.status).to.not.equal(0);
+    expect(result.jsonOutput?.name).to.equal('NoFields');
+  });
+
+  it('lists the asset allowlist (starts empty before any replace)', () => {
+    const result = execCmd<{ assets: Asset[] }>(
+      `agent mcp asset list --mcp-server-id ${serverId} --target-org ${targetOrg} --json`,
+      { ensureExitCode: 0 }
+    );
+    expect(result.jsonOutput!.result).to.have.property('assets');
+  });
+
+  it('replaces the asset allowlist using an asset discovered at create time', () => {
+    // Use an asset surfaced by create (the auto-fetch). This avoids a separate live
+    // /fetch round-trip, which can hang against sleepy free-tier test servers.
+    const candidate = discoveredAssets[0]?.name;
+    if (!candidate) {
+      console.log('Server advertised no assets at create — skipping allowlist replace assertion');
+      return;
+    }
+
+    const file = join(tmpdir(), `nut-assets-${Date.now()}.json`);
+    writeFileSync(file, JSON.stringify({ assets: [{ name: candidate, active: true }] }));
+
+    const result = execCmd<{ assets: Asset[] }>(
+      `agent mcp asset replace --mcp-server-id ${serverId} --assets-file ${file} --target-org ${targetOrg} --json`,
+      { ensureExitCode: 0 }
+    );
+    const active = result.jsonOutput!.result.assets.filter((a) => a.active).map((a) => a.name);
+    expect(active).to.include(candidate);
+  });
+
+  it('deletes the server and confirms it is gone', () => {
+    const del = execCmd<{ id: string; deleted: boolean }>(
+      `agent mcp delete --mcp-server-id ${serverId} --no-prompt --target-org ${targetOrg} --json`,
+      { ensureExitCode: 0 }
+    );
+    expect(del.jsonOutput!.result.deleted).to.be.true;
+
+    const gone = execCmd(`agent mcp get --mcp-server-id ${serverId} --target-org ${targetOrg} --json`);
+    expect(gone.jsonOutput?.status).to.not.equal(0);
+    expect(gone.jsonOutput?.name).to.equal('GetMcpServerFailed');
+    serverId = '';
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// MCP server ABM — OAuth (create → get → delete)
+// ═══════════════════════════════════════════════════════════════
+describe('agent mcp OAuth ABM NUTs', function () {
+  this.timeout(10 * 60 * 1000);
+
+  const url = process.env.MCP_OAUTH_URL;
+  const idp = process.env.MCP_OAUTH_IDP;
+  const clientId = process.env.MCP_OAUTH_CLIENT_ID;
+  const clientSecret = process.env.MCP_OAUTH_CLIENT_SECRET;
+  const scope = process.env.MCP_OAUTH_SCOPE ?? 'read';
+  let serverId = '';
+
+  before(function skipIfNoConfig() {
+    if (!targetOrg) this.skip();
+    if (!url || !idp || !clientId || !clientSecret) {
+      console.log(
+        'Skipping OAuth MCP ABM: set MCP_OAUTH_URL, MCP_OAUTH_IDP, MCP_OAUTH_CLIENT_ID, MCP_OAUTH_CLIENT_SECRET'
+      );
+      this.skip();
+    }
+  });
+
+  after('best-effort cleanup', () => {
+    if (serverId) {
+      execCmd(`agent mcp delete --mcp-server-id ${serverId} --no-prompt --target-org ${targetOrg} --json`);
+    }
+  });
+
+  it('creates an OAuth MCP server', () => {
+    const name = `nutOAuth${Date.now()}`;
+    // Interactive callers should pipe the secret via `--client-secret -`; in the NUT we
+    // pass it inline (the test org is disposable) so the run stays non-interactive.
+    const result = execCmd<{ server: McpServer & { authorization?: { authType: string } }; assets: Asset[] }>(
+      `agent mcp create --name "${name}" --server-url "${url}" --auth-type OAUTH --identity-provider "${idp}" --client-id "${clientId}" --client-secret "${clientSecret}" --scope "${scope}" --target-org ${targetOrg} --json`,
+      { ensureExitCode: 0 }
+    );
+    const { server } = result.jsonOutput!.result;
+    expect(server).to.have.property('id');
+    expect(server.status).to.equal('ACTIVE');
+    serverId = server.id;
+    console.log(`Created OAuth MCP server ${serverId}`);
+  });
+
+  it('gets the server and confirms OAuth metadata (secret stripped)', () => {
+    const result = execCmd<McpServer & { authorization?: { authType: string; clientSecret?: string } }>(
+      `agent mcp get --mcp-server-id ${serverId} --target-org ${targetOrg} --json`,
+      { ensureExitCode: 0 }
+    );
+    const auth = result.jsonOutput!.result.authorization;
+    expect(auth?.authType).to.equal('OAUTH');
+    expect(auth).to.not.have.property('clientSecret');
+  });
+
+  it('deletes the OAuth server', () => {
+    const del = execCmd<{ deleted: boolean }>(
+      `agent mcp delete --mcp-server-id ${serverId} --no-prompt --target-org ${targetOrg} --json`,
+      { ensureExitCode: 0 }
+    );
+    expect(del.jsonOutput!.result.deleted).to.be.true;
+    serverId = '';
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1411,15 +1411,15 @@
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
-"@salesforce/agents@^1.8.1":
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/@salesforce/agents/-/agents-1.8.1.tgz#3739755f7356c36b8b88f861a13c0f72797d57ba"
-  integrity sha512-DyybLIzO/eo1xLxus02e9W1e/xY6Jwet531qztaUfMF/YCW+Mbonn6WJFeN2orWJcSop5TOz1C5tkDOrNAQsDg==
+"@salesforce/agents@^1.8.4":
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/@salesforce/agents/-/agents-1.8.4.tgz#2d51be8575800d066d56ce542d8040439ccfe8fc"
+  integrity sha512-ag5OxiKmBJY82IEWSZoK5NtvpgJCW1VhsSi/vi4quyvEOLpNyPKfGcFahJJaXMB5VFGRSdSa9+LIoqMmL9nlHQ==
   dependencies:
     "@salesforce/core" "^8.31.0"
     "@salesforce/kit" "^3.2.6"
-    "@salesforce/source-deploy-retrieve" "^12.36.0"
-    "@salesforce/types" "^1.7.1"
+    "@salesforce/source-deploy-retrieve" "^12.36.2"
+    "@salesforce/types" "^1.7.3"
     fast-xml-parser "^5.8.0"
     nock "^14.0.15"
     yaml "^2.8.4"
@@ -1544,10 +1544,30 @@
     cli-progress "^3.12.0"
     terminal-link "^3.0.0"
 
-"@salesforce/source-deploy-retrieve@^12.35.3", "@salesforce/source-deploy-retrieve@^12.36.0":
+"@salesforce/source-deploy-retrieve@^12.35.3":
   version "12.36.1"
   resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-12.36.1.tgz#c054e6efc95fefc29179e6ee83b81ff145187a51"
   integrity sha512-W+jVWAovoAfbtgCRzBKtVxKhQoBzFoEyAHLiCtT8U84/lBLIqeTCklYTA155GRSdC8DwQ26j0NKiDgpR79TqcQ==
+  dependencies:
+    "@salesforce/core" "^8.31.0"
+    "@salesforce/kit" "^3.2.4"
+    "@salesforce/ts-types" "^2.0.12"
+    "@salesforce/types" "^1.6.0"
+    fast-levenshtein "^3.0.0"
+    fast-xml-parser "^5.7.3"
+    got "^11.8.6"
+    graceful-fs "^4.2.11"
+    ignore "^5.3.2"
+    jszip "^3.10.1"
+    mime "2.6.0"
+    minimatch "^9.0.9"
+    proxy-agent "^6.5.0"
+    yaml "^2.9.0"
+
+"@salesforce/source-deploy-retrieve@^12.36.2":
+  version "12.36.2"
+  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-12.36.2.tgz#54b8f414687960581a5513216bcd5b77b9489136"
+  integrity sha512-N3+dnM2EBsviXbnzP89iuBbdSyzB5b3RqUPZwyCw99SF6x6u9GKQVL164kfWyozl4XtZnhTQvbU75qkriFYWoQ==
   dependencies:
     "@salesforce/core" "^8.31.0"
     "@salesforce/kit" "^3.2.4"
@@ -1574,7 +1594,7 @@
   resolved "https://registry.yarnpkg.com/@salesforce/types/-/types-1.7.1.tgz#8983f87508ac21bfb334fe650b7cafdfe4278cf8"
   integrity sha512-PyV3ZyZum8bjO1LByNXWCSOGt1b9X9x2knIiFWgnYTsHmLK8OP+f6i+wPh4qu1e8+Zr+hNV0rTKVP8p/kCGqyQ==
 
-"@salesforce/types@^1.6.0", "@salesforce/types@^1.7.1":
+"@salesforce/types@^1.6.0", "@salesforce/types@^1.7.3":
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/@salesforce/types/-/types-1.7.3.tgz#e670a92439a183a219bab81a3ae596d79b9fd589"
   integrity sha512-6rzz2njJ4IEL9q1TgM4cEUPbiKcrQmKlTk5Ki6q7m5c6spYkbbA5jPxX3/8F9Ux5UKu0r9QCKAfZ33b88lq1PA==


### PR DESCRIPTION
# PR 2 of 2 — `salesforcecli/plugin-agent`

**Branch:** `feat/api-catalog-commands`
**Title:** `feat: add sf agent mcp commands for MCP server management`
**Depends on:** forcedotcom/agents#300 (needs `@salesforce/agents` with `ApiCatalog`; bump the dep once that PR publishes).

## Summary

Adds 8 `sf agent mcp ...` commands — thin wrappers over `ApiCatalog` from
`@salesforce/agents` — for managing MCP (Model Context Protocol) server registrations
via the API Catalog Connect API. Mirrors the existing `sf agent adl ...` command set.
All commands are `state = 'preview'`.

Enables the ADLC team to manage MCP servers from the CLI.

## Commands

| Command | Operation |
|---|---|
| `sf agent mcp list` | list MCP servers (`--label/--type/--status`) |
| `sf agent mcp create` | register an EXTERNAL MCP server |
| `sf agent mcp get` | get one MCP server |
| `sf agent mcp update` | update metadata / auth (PUT, partial) |
| `sf agent mcp delete` | delete (with confirm / `--no-prompt`) |
| `sf agent mcp fetch` | live fetch of remote assets |
| `sf agent mcp asset list` | list the asset allowlist |
| `sf agent mcp asset replace` | replace the asset allowlist from a JSON file |

## Notable decisions

- **MCP-only scope.** The catalog read commands (sources/apis/versions/operations) were
  intentionally left out of this first cut; only MCP server management ships.
- **Namespace `sf agent mcp`** (not `sf agent api-catalog`) — shorter, MCP-focused.
- **`delete` in `--json` mode** skips the confirmation prompt; confirm is gated by
  `!flags['no-prompt'] && !this.jsonEnabled()`.
- **`--client-secret`** uses `allowStdin: true`; pass `--client-secret -` to pipe it from
  stdin so it stays out of shell history.
- **`mcp list --status`** is limited to `ACTIVE` / `DISCONNECTED` (the only values the
  Connect API accepts as a filter).
- Generated artifacts updated: `command-snapshot.json` (+8), `schemas/` (+8 `agent-mcp-*`),
  `README.md`.

## Test plan

- `yarn build` (compile + lint) — clean.
- `yarn test:only` — 14 command unit tests pass (list filters, create NO_AUTH + auto-fetched
  assets, create OAUTH body, OAUTH validation, update partial-body + NoFields, delete
  `--no-prompt` + `--json`, asset replace both shapes + InvalidShape, get secret-stripped,
  fetch mocked, asset list). All mocked — no network.
- `yarn test` gates `snapshot:compare` + `schema:compare` — pass.
- NUT (`test/nuts/agent.mcp.nut.ts`) — env-gated, skips cleanly without config. Verified
  green against a live org (13/13: smoke + NoAuth ABM + OAuth ABM, create→get→update→
  asset allowlist→delete).

## Remaining before GA

- Bump `@salesforce/agents` to the version published from PR 1.
- Confirm the `sf agent mcp` namespace with the ADLC team.
- Open question for core team: `update` persists `description` but not `label` — confirm
  whether label is intentionally immutable.
