### PR TITLE
feat: wire --test-runner agentforce-studio into agent generate   test-spec @W-22904110@

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -187,7 +187,7 @@
     "command": "agent:generate:test-spec",
     "flagAliases": [],
     "flagChars": ["d", "f"],
-    "flags": ["flags-dir", "force-overwrite", "from-definition", "output-file"],
+    "flags": ["flags-dir", "force-overwrite", "from-definition", "output-file", "test-runner"],
     "plugin": "@salesforce/plugin-agent"
   },
   {

--- a/messages/agent.generate.test-spec.md
+++ b/messages/agent.generate.test-spec.md
@@ -17,13 +17,13 @@ To generate a specific agent test case, this command prompts you for this inform
 
 You can manually add contextVariables to test cases in the generated YAML file to inject contextual data (such as CaseId or RoutableId) into agent sessions. This is useful for testing agent behavior with different contextual information.
 
-When your test spec is ready, you then run the "agent test create" command to actually create the test in your org and synchronize the metadata with your DX project. The metadata type for an agent test is AiEvaluationDefinition.
+When your test spec is ready, you then run the "agent test create" command to actually create the test in your org and synchronize the metadata with your DX project. The metadata type for an agent test is `AiEvaluationDefinition` (legacy testing-center) or `AiTestingDefinition` (Agentforce Studio / NGT), selected via --test-runner.
 
-If you have an existing AiEvaluationDefinition metadata XML file in your DX project, you can generate its equivalent YAML test spec file with the --from-definition flag.
+If you have an existing AiEvaluationDefinition or AiTestingDefinition metadata XML file in your DX project, you can generate its equivalent YAML test spec file with the --from-definition flag. The runner is inferred from the file extension; pass --test-runner to override.
 
 # flags.from-definition.summary
 
-Filepath to the AIEvaluationDefinition metadata XML file in your DX project that you want to convert to a test spec YAML file.
+Filepath to an AiEvaluationDefinition or AiTestingDefinition metadata XML file in your DX project that you want to convert to a test spec YAML file.
 
 # flags.force-overwrite.summary
 
@@ -31,7 +31,15 @@ Don't prompt for confirmation when overwriting an existing test spec YAML file.
 
 # flags.output-file.summary
 
-Name of the generated test spec YAML file. Default value is "specs/<AGENT_API_NAME>-testSpec.yaml".
+Name of the generated test spec YAML file. Default value is "specs/<AGENT_API_NAME>-testSpec.yaml" (legacy) or "specs/<AGENT_API_NAME>-ngtTestSpec.yaml" (Agentforce Studio).
+
+# flags.test-runner.summary
+
+Explicitly specify which test runner to use (agentforce-studio or testing-center).
+
+# flags.test-runner.description
+
+By default, the command automatically detects which test runner to use based on the test definition metadata type in your org. Use this flag to explicitly specify the runner type. 'agentforce-studio' uses AiTestingDefinition metadata. 'testing-center' uses AiEvaluationDefinition metadata.
 
 # examples
 
@@ -39,21 +47,41 @@ Name of the generated test spec YAML file. Default value is "specs/<AGENT_API_NA
 
   <%= config.bin %> <%= command.id %>
 
+- Generate an Agentforce Studio (NGT) test spec YAML file interactively:
+
+  <%= config.bin %> <%= command.id %> --test-runner agentforce-studio
+
 - Generate an agent test spec YAML file and specify a name for the new file; if the file exists, overwrite it without confirmation:
 
   <%= config.bin %> <%= command.id %> --output-file specs/Resort_Manager-new-version-testSpec.yaml --force-overwrite
 
 - Generate an agent test spec YAML file from an existing AiEvaluationDefinition metadata XML file in your DX project:
 
-  <%= config.bin %> <%= command.id %> --from-definition force-app//main/default/aiEvaluationDefinitions/Resort_Manager_Tests.aiEvaluationDefinition-meta.xml
+  <%= config.bin %> <%= command.id %> --from-definition force-app/main/default/aiEvaluationDefinitions/Resort_Manager_Tests.aiEvaluationDefinition-meta.xml
+
+- Generate an Agentforce Studio (NGT) test spec YAML file from an existing AiTestingDefinition metadata XML file:
+
+  <%= config.bin %> <%= command.id %> --from-definition force-app/main/default/aiTestingDefinitions/Returns_Checkout_Tests.aiTestingDefinition-meta.xml
 
 # info.cancel
 
 Operation canceled.
 
+# warning.NoConversationHistoryForTaskResolution
+
+Test case #%s uses the 'task_resolution' scorer, which requires `conversationHistory` on at least one input. Add conversationHistory by hand to the YAML before running 'agent test create', or accept the boilerplate prompt.
+
 # error.InvalidAiEvaluationDefinition
 
 File must be an AiEvaluationDefinition metadata XML file.
+
+# error.UnknownDefinitionExtension
+
+File must be an AiEvaluationDefinition or AiTestingDefinition metadata XML file (ends with `.aiEvaluationDefinition-meta.xml` or `.aiTestingDefinition-meta.xml`). Found: %s
+
+# error.RunnerMismatch
+
+--test-runner=%s contradicts the metadata file extension, which implies %s. Drop --test-runner, or pick the matching value.
 
 # error.NoAgentsFound
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@inquirer/prompts": "^7.10.1",
     "@oclif/core": "^4",
     "@oclif/multi-stage-output": "^0.8.36",
-    "@salesforce/agents": "^1.8.4",
+    "@salesforce/agents": "^1.9.0",
     "@salesforce/core": "^8.28.3",
     "@salesforce/kit": "^3.2.6",
     "@salesforce/sf-plugins-core": "^12.2.6",

--- a/src/commands/agent/generate/test-spec.ts
+++ b/src/commands/agent/generate/test-spec.ts
@@ -18,7 +18,17 @@ import { join, parse } from 'node:path';
 import { existsSync } from 'node:fs';
 import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
 import { Messages, SfError, SfProject } from '@salesforce/core';
-import { AgentTest } from '@salesforce/agents';
+import {
+  AgentTest,
+  NgtScorerCatalog,
+  type KnownNgtScorerName,
+  type NgtConversationTurn,
+  type NgtContextVar,
+  type NgtTestCase,
+  type NgtTestCaseInput,
+  type NgtTestCaseScorer,
+  type NgtTestSpec,
+} from '@salesforce/agents';
 import { select, input, confirm, checkbox } from '@inquirer/prompts';
 import { XMLParser } from 'fast-xml-parser';
 import { ComponentSet, ComponentSetBuilder } from '@salesforce/source-deploy-retrieve';
@@ -26,6 +36,9 @@ import { warn } from '@oclif/core/errors';
 import { ensureArray } from '@salesforce/kit';
 import { theme } from '../../../inquirer-theme.js';
 import yesNoOrCancel from '../../../yes-no-cancel.js';
+import { testRunnerFlag } from '../../../flags.js';
+
+type TestRunner = 'agentforce-studio' | 'testing-center';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-agent', 'agent.generate.test-spec');
@@ -406,6 +419,16 @@ export function ensureYamlExtension(filePath: string): string {
   return normalized;
 }
 
+/**
+ * Infer the test runner from the file extension of an AiEvaluationDefinition / AiTestingDefinition
+ * metadata XML file. Throws when the extension matches neither.
+ */
+export function inferRunnerFromMdPath(mdPath: string): TestRunner {
+  if (mdPath.endsWith('aiTestingDefinition-meta.xml')) return 'agentforce-studio';
+  if (mdPath.endsWith('aiEvaluationDefinition-meta.xml')) return 'testing-center';
+  throw messages.createError('error.UnknownDefinitionExtension', [mdPath]);
+}
+
 async function promptUntilUniqueFile(subjectName: string, filePath?: string): Promise<string | undefined> {
   const outputFile =
     filePath ??
@@ -450,10 +473,180 @@ async function promptUntilUniqueFile(subjectName: string, filePath?: string): Pr
 async function determineFilePath(
   subjectName: string,
   outputFile: string | undefined,
-  forceOverwrite: boolean
+  forceOverwrite: boolean,
+  testRunner: TestRunner = 'testing-center'
 ): Promise<string | undefined> {
-  const defaultFile = ensureYamlExtension(outputFile ?? join('specs', `${subjectName}-testSpec.yaml`));
+  const suffix = testRunner === 'agentforce-studio' ? '-ngtTestSpec.yaml' : '-testSpec.yaml';
+  const defaultFile = ensureYamlExtension(outputFile ?? join('specs', `${subjectName}${suffix}`));
   return forceOverwrite ? defaultFile : promptUntilUniqueFile(subjectName, defaultFile);
+}
+
+const NGT_BOILERPLATE_HISTORY: NgtConversationTurn[] = [
+  { role: 'user', message: 'example user message' },
+  { role: 'agent', message: 'example agent message', topic: 'Example_agent_topic' },
+];
+
+async function promptForNgtContextVariables(): Promise<NgtContextVar[]> {
+  const vars: NgtContextVar[] = [];
+  let wantsMore = await confirm({ message: 'Add context variables to this case', default: false, theme });
+  while (wantsMore) {
+    // eslint-disable-next-line no-await-in-loop
+    const name = await input({
+      message: 'Variable name',
+      validate: (d: string): boolean | string => d.length > 0 || 'Name cannot be empty',
+      theme,
+    });
+    // eslint-disable-next-line no-await-in-loop
+    const value = await input({ message: 'Variable value', theme });
+    vars.push({ name, value });
+    // eslint-disable-next-line no-await-in-loop
+    wantsMore = await confirm({ message: 'Add another context variable', default: false, theme });
+  }
+  return vars;
+}
+
+async function promptForNgtUtterance(message: string): Promise<string> {
+  return input({
+    message,
+    validate: (d: string): boolean | string => d.length > 0 || 'utterance cannot be empty',
+    theme,
+  });
+}
+
+async function promptForNgtInputs(): Promise<NgtTestCaseInput[]> {
+  const isMulti = await confirm({
+    message: 'Does this case have multiple input phrasings sharing one scorer set',
+    default: false,
+    theme,
+  });
+
+  // contextVariables / conversationHistory are decided once and shared across the input set.
+  const contextVariables = await promptForNgtContextVariables();
+  const wantsHistory = await confirm({
+    message: 'Generate boilerplate conversation history for this case',
+    default: false,
+    theme,
+  });
+  const conversationHistory = wantsHistory ? [...NGT_BOILERPLATE_HISTORY] : undefined;
+
+  const utterances: string[] = [];
+  if (!isMulti) {
+    utterances.push(await promptForNgtUtterance('Utterance'));
+  } else {
+    utterances.push(await promptForNgtUtterance('Utterance #1'));
+    let addAnother = await confirm({ message: 'Add another input utterance', default: true, theme });
+    while (addAnother) {
+      // eslint-disable-next-line no-await-in-loop
+      utterances.push(await promptForNgtUtterance(`Utterance #${utterances.length + 1}`));
+      // eslint-disable-next-line no-await-in-loop
+      addAnother = await confirm({ message: 'Add another input utterance', default: false, theme });
+    }
+  }
+
+  return utterances.map((utterance) => {
+    const ngtInput: NgtTestCaseInput = { utterance };
+    if (contextVariables.length > 0) ngtInput.contextVariables = contextVariables;
+    if (conversationHistory) ngtInput.conversationHistory = conversationHistory;
+    return ngtInput;
+  });
+}
+
+/* eslint-disable camelcase */
+const NGT_SCORER_HELP: Partial<Record<KnownNgtScorerName, string>> = {
+  topic_sequence_match: 'Topic API name (DeveloperName from a GenAiPlugin).',
+  action_sequence_match:
+    "Single action API name, OR a Python-list-style string for multi-action: ['Verify_Customer','Get_Order_Status'].",
+  agent_handoff_match: "Target agent's DeveloperName (NOT label).",
+  bot_response_rating: "Natural-language assertion (LLM-judged). Example: 'Agent confirms the cancellation.'",
+  response_match: "Natural-language assertion (LLM-judged). Example: 'Agent confirms the cancellation.'",
+};
+/* eslint-enable camelcase */
+
+async function promptForNgtScorerExpected(
+  scorerName: KnownNgtScorerName,
+  topics: string[],
+  bots: string[],
+  subjectName: string
+): Promise<string> {
+  const help = NGT_SCORER_HELP[scorerName] ?? '';
+
+  if (scorerName === 'topic_sequence_match' && topics.length > 0) {
+    return select<string>({
+      message: `Expected for ${scorerName}: ${help}`,
+      choices: topics.map((t) => ({ name: t, value: t })),
+      theme,
+    });
+  }
+  if (scorerName === 'agent_handoff_match') {
+    const targets = bots.filter((b) => b !== subjectName);
+    if (targets.length > 0) {
+      return select<string>({
+        message: `Expected for ${scorerName}: ${help}`,
+        choices: targets.map((t) => ({ name: t, value: t })),
+        theme,
+      });
+    }
+  }
+
+  return input({
+    message: `Expected for ${scorerName}${help ? `: ${help}` : ''}`,
+    validate: (d: string): boolean | string => d.length > 0 || 'expected cannot be empty',
+    theme,
+  });
+}
+
+async function promptForNgtScorers(
+  topics: string[],
+  bots: string[],
+  subjectName: string
+): Promise<NgtTestCaseScorer[]> {
+  const choices = (Object.keys(NgtScorerCatalog) as KnownNgtScorerName[]).map((n) => ({ name: n, value: n }));
+  const selected = await checkbox<KnownNgtScorerName>({
+    message: 'Select scorers for this test case',
+    choices,
+    required: true,
+    theme,
+  });
+
+  const scorers: NgtTestCaseScorer[] = [];
+  for (const name of selected) {
+    if (NgtScorerCatalog[name].needsExpected) {
+      // eslint-disable-next-line no-await-in-loop
+      const expected = await promptForNgtScorerExpected(name, topics, bots, subjectName);
+      scorers.push({ name, expected });
+    } else {
+      scorers.push({ name });
+    }
+  }
+  return scorers;
+}
+
+export async function promptForNgtTestCase(
+  topics: string[],
+  bots: string[],
+  subjectName: string,
+  caseNumber: number,
+  log: (msg?: string) => void
+): Promise<NgtTestCase> {
+  const inputs = await promptForNgtInputs();
+  const scorers = await promptForNgtScorers(topics, bots, subjectName);
+
+  const usesTaskResolution = scorers.some((s) => s.name === 'task_resolution');
+  const hasHistory = inputs.some((i) => Array.isArray(i.conversationHistory) && i.conversationHistory.length > 0);
+  if (usesTaskResolution && !hasHistory) {
+    const wantsBoilerplate = await confirm({
+      message: 'task_resolution requires conversationHistory. Add boilerplate conversation history now',
+      default: true,
+      theme,
+    });
+    if (wantsBoilerplate) {
+      const stamped = inputs.map((i) => ({ ...i, conversationHistory: [...NGT_BOILERPLATE_HISTORY] }));
+      return { inputs: stamped, scorers };
+    }
+    log(messages.getMessage('warning.NoConversationHistoryForTaskResolution', [caseNumber.toString()]));
+  }
+
+  return { inputs, scorers };
 }
 
 export default class AgentGenerateTestSpec extends SfCommand<void> {
@@ -467,13 +660,6 @@ export default class AgentGenerateTestSpec extends SfCommand<void> {
       char: 'd',
       exists: true,
       summary: messages.getMessage('flags.from-definition.summary'),
-      parse: async (raw): Promise<string> => {
-        if (!raw.endsWith('aiEvaluationDefinition-meta.xml')) {
-          throw messages.createError('error.InvalidAiEvaluationDefinition');
-        }
-
-        return Promise.resolve(raw);
-      },
     }),
     'force-overwrite': Flags.boolean({
       summary: messages.getMessage('flags.force-overwrite.summary'),
@@ -483,6 +669,7 @@ export default class AgentGenerateTestSpec extends SfCommand<void> {
       summary: messages.getMessage('flags.output-file.summary'),
       parse: async (raw): Promise<string> => Promise.resolve(ensureYamlExtension(raw)),
     }),
+    'test-runner': testRunnerFlag,
   };
 
   public async run(): Promise<void> {
@@ -500,10 +687,21 @@ export default class AgentGenerateTestSpec extends SfCommand<void> {
     });
 
     if (flags['from-definition']) {
+      const inferredRunner = inferRunnerFromMdPath(flags['from-definition']);
+      if (flags['test-runner'] && flags['test-runner'] !== inferredRunner) {
+        throw messages.createError('error.RunnerMismatch', [flags['test-runner'], inferredRunner]);
+      }
+      const testRunner = flags['test-runner'] ?? inferredRunner;
+
       const agentTest = new AgentTest({ mdPath: flags['from-definition'] });
       const spec = await agentTest.getTestSpec();
 
-      const outputFile = await determineFilePath(spec.subjectName, flags['output-file'], flags['force-overwrite']);
+      const outputFile = await determineFilePath(
+        spec.subjectName,
+        flags['output-file'],
+        flags['force-overwrite'],
+        testRunner
+      );
       if (!outputFile) {
         this.log(messages.getMessage('info.cancel'));
         return;
@@ -524,6 +722,8 @@ export default class AgentGenerateTestSpec extends SfCommand<void> {
       throw messages.createError('error.NoAgentsFound', [directoryPaths.join(', ')]);
     }
 
+    const testRunner: TestRunner = flags['test-runner'] ?? 'testing-center';
+
     const subjectType = (await select<string>({
       message: 'What are you testing',
       choices: ['AGENT'],
@@ -536,7 +736,7 @@ export default class AgentGenerateTestSpec extends SfCommand<void> {
       theme,
     });
 
-    const outputFile = await determineFilePath(subjectName, flags['output-file'], flags['force-overwrite']);
+    const outputFile = await determineFilePath(subjectName, flags['output-file'], flags['force-overwrite'], testRunner);
     if (!outputFile) {
       this.log(messages.getMessage('info.cancel'));
       return;
@@ -561,6 +761,47 @@ export default class AgentGenerateTestSpec extends SfCommand<void> {
       message: 'Enter a description for the test (optional)',
       theme,
     });
+
+    if (testRunner === 'agentforce-studio') {
+      const subjectVersion = await input({
+        message: 'Enter the agent version (e.g. v1)',
+        default: 'v1',
+        theme,
+      });
+
+      const ngtTestCases: NgtTestCase[] = [];
+      do {
+        this.log();
+        this.styledHeader(`Adding test case #${ngtTestCases.length + 1}`);
+        // eslint-disable-next-line no-await-in-loop
+        const tc = await promptForNgtTestCase(
+          Object.keys(genAiPlugins),
+          bots,
+          subjectName,
+          ngtTestCases.length + 1,
+          (msg) => this.warn(msg ?? '')
+        );
+        ngtTestCases.push(tc);
+      } while ( // eslint-disable-next-line no-await-in-loop
+        await confirm({ message: 'Do you want to add another test case', default: true })
+      );
+
+      this.log();
+
+      const ngtSpec: NgtTestSpec = {
+        name,
+        description: description || undefined,
+        subjectType,
+        subjectName,
+        subjectVersion,
+        testCases: ngtTestCases,
+      };
+
+      const agentTest = new AgentTest({ specData: ngtSpec });
+      await agentTest.writeTestSpec(outputFile);
+      this.log(`Created ${outputFile}`);
+      return;
+    }
 
     const testCases = [];
     do {

--- a/test/commands/agent/generate/test-spec.ngt.test.ts
+++ b/test/commands/agent/generate/test-spec.ngt.test.ts
@@ -1,0 +1,269 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import esmock from 'esmock';
+import type { NgtTestCase } from '@salesforce/agents';
+
+type ConfirmCfg = { message: string; default?: boolean };
+type InputCfg = { message: string };
+type CheckboxCfg<T> = { message: string; choices: Array<{ name: string; value: T }> };
+type SelectCfg<T> = { message: string; choices: Array<{ name: string; value: T }> };
+
+/**
+ * Build a deterministic prompt-stub harness. Each prompt looks up its scripted
+ * answer by message-substring; an unmatched message falls through to the
+ * supplied default so the tests fail loudly if a flow asks something we
+ * weren't expecting.
+ */
+function harness(answers: {
+  confirms?: Record<string, boolean>;
+  inputs?: Record<string, string>;
+  checkbox?: Record<string, unknown[]>;
+  select?: Record<string, unknown>;
+  warns?: string[];
+}) {
+  const confirms = answers.confirms ?? {};
+  const inputs = answers.inputs ?? {};
+  const checkboxAnswers = answers.checkbox ?? {};
+  const selectAnswers = answers.select ?? {};
+  const warns = answers.warns ?? [];
+
+  const matchKey = <K extends string>(message: string, table: Record<K, unknown>): K | undefined =>
+    (Object.keys(table) as K[]).find((k) => message.includes(k));
+
+  const confirmStub = sinon.stub().callsFake((cfg: ConfirmCfg) => {
+    const k = matchKey(cfg.message, confirms);
+    if (k === undefined) return Promise.resolve(cfg.default ?? false);
+    return Promise.resolve(confirms[k]);
+  });
+
+  const inputStub = sinon.stub().callsFake((cfg: InputCfg) => {
+    const k = matchKey(cfg.message, inputs);
+    if (k === undefined) throw new Error(`Unexpected input prompt: ${cfg.message}`);
+    return Promise.resolve(inputs[k]);
+  });
+
+  const checkboxStub = sinon.stub().callsFake((cfg: CheckboxCfg<unknown>) => {
+    const k = matchKey(cfg.message, checkboxAnswers);
+    if (k === undefined) throw new Error(`Unexpected checkbox prompt: ${cfg.message}`);
+    return Promise.resolve(checkboxAnswers[k]);
+  });
+
+  const selectStub = sinon.stub().callsFake((cfg: SelectCfg<unknown>) => {
+    const k = matchKey(cfg.message, selectAnswers);
+    if (k === undefined) throw new Error(`Unexpected select prompt: ${cfg.message}`);
+    return Promise.resolve(selectAnswers[k]);
+  });
+
+  return { confirms, confirmStub, inputStub, checkboxStub, selectStub, warns };
+}
+
+async function loadModWithPrompts(harnessHandles: ReturnType<typeof harness>): Promise<any> {
+  return esmock('../../../../src/commands/agent/generate/test-spec.js', {
+    '@inquirer/prompts': {
+      confirm: harnessHandles.confirmStub,
+      input: harnessHandles.inputStub,
+      checkbox: harnessHandles.checkboxStub,
+      select: harnessHandles.selectStub,
+    },
+  });
+}
+
+describe('promptForNgtTestCase (NGT walkthrough)', () => {
+  const TOPICS = ['order_status', 'returns', 'identity_verification'];
+  const BOTS = ['ReturnsAgent', 'SDRAgent'];
+  const SUBJECT = 'ReturnsAgent';
+
+  it('builds a single-input case with assertion + LLM-judged + numeric scorers', async () => {
+    const h = harness({
+      confirms: {
+        'multiple input phrasings': false,
+        'context variables': false,
+        'Generate boilerplate conversation history': false,
+      },
+      inputs: { Utterance: 'Where is my order #12345?' },
+      checkbox: {
+        'Select scorers': ['topic_sequence_match', 'bot_response_rating', 'output_latency_milliseconds'],
+      },
+      select: {
+        // eslint-disable-next-line camelcase
+        topic_sequence_match: 'order_status',
+      },
+      // bot_response_rating expected falls through to inputStub
+    });
+    h.inputStub.callsFake((cfg: InputCfg) => {
+      if (cfg.message.startsWith('Utterance')) return Promise.resolve('Where is my order #12345?');
+      if (cfg.message.includes('bot_response_rating')) {
+        return Promise.resolve('Agent looks up the order and returns its status');
+      }
+      throw new Error(`Unexpected input prompt: ${cfg.message}`);
+    });
+
+    const mod = await loadModWithPrompts(h);
+    const tc: NgtTestCase = await mod.promptForNgtTestCase(TOPICS, BOTS, SUBJECT, 1, () => {});
+
+    expect(tc.inputs).to.have.length(1);
+    expect(tc.inputs[0].utterance).to.equal('Where is my order #12345?');
+    expect(tc.inputs[0].contextVariables).to.be.undefined;
+    expect(tc.inputs[0].conversationHistory).to.be.undefined;
+
+    expect(tc.scorers).to.deep.equal([
+      { name: 'topic_sequence_match', expected: 'order_status' },
+      { name: 'bot_response_rating', expected: 'Agent looks up the order and returns its status' },
+      { name: 'output_latency_milliseconds' },
+    ]);
+  });
+
+  it('skips the expected prompt entirely for quality scorers (needsExpected=false)', async () => {
+    const h = harness({
+      confirms: {
+        'multiple input phrasings': false,
+        'context variables': false,
+        'Generate boilerplate conversation history': false,
+      },
+      inputs: { Utterance: 'Show order details' },
+      checkbox: { 'Select scorers': ['factuality', 'completeness'] },
+    });
+
+    const mod = await loadModWithPrompts(h);
+    const tc: NgtTestCase = await mod.promptForNgtTestCase(TOPICS, BOTS, SUBJECT, 1, () => {});
+
+    expect(tc.scorers).to.deep.equal([{ name: 'factuality' }, { name: 'completeness' }]);
+    // No expected prompts were asked.
+    const expectedPromptCalls = h.inputStub
+      .getCalls()
+      .filter((c) => (c.args[0] as InputCfg).message.startsWith('Expected for'));
+    expect(expectedPromptCalls).to.have.length(0);
+  });
+
+  it('warns when task_resolution is selected without conversationHistory and the user declines boilerplate', async () => {
+    const warnCalls: string[] = [];
+    const h = harness({
+      confirms: {
+        'multiple input phrasings': false,
+        'context variables': false,
+        'Generate boilerplate conversation history': false,
+        'task_resolution requires conversationHistory': false,
+      },
+      inputs: { Utterance: 'Cancel my order' },
+      checkbox: { 'Select scorers': ['task_resolution'] },
+    });
+
+    const mod = await loadModWithPrompts(h);
+    const tc: NgtTestCase = await mod.promptForNgtTestCase(TOPICS, BOTS, SUBJECT, 4, (m: string) => warnCalls.push(m));
+
+    expect(tc.scorers).to.deep.equal([{ name: 'task_resolution' }]);
+    expect(tc.inputs[0].conversationHistory).to.be.undefined;
+    expect(warnCalls.join('\n')).to.match(/task_resolution|conversationHistory/i);
+  });
+
+  it('auto-stamps boilerplate conversationHistory when user accepts the task_resolution rescue prompt', async () => {
+    const h = harness({
+      confirms: {
+        'multiple input phrasings': false,
+        'context variables': false,
+        'Generate boilerplate conversation history': false,
+        'task_resolution requires conversationHistory': true,
+      },
+      inputs: { Utterance: 'Yes, my email is jane@example.com' },
+      checkbox: { 'Select scorers': ['task_resolution'] },
+    });
+
+    const mod = await loadModWithPrompts(h);
+    const tc: NgtTestCase = await mod.promptForNgtTestCase(TOPICS, BOTS, SUBJECT, 4, () => {});
+
+    expect(tc.inputs[0].conversationHistory).to.have.length(2);
+    expect(tc.inputs[0].conversationHistory?.[0]).to.deep.equal({ role: 'user', message: 'example user message' });
+    expect(tc.inputs[0].conversationHistory?.[1]).to.deep.equal({
+      role: 'agent',
+      message: 'example agent message',
+      topic: 'Example_agent_topic',
+    });
+  });
+
+  it('fans out a multi-input case with a shared scorer set', async () => {
+    const h = harness({
+      confirms: {
+        'multiple input phrasings': true,
+        'context variables': false,
+        'Generate boilerplate conversation history': false,
+      },
+      checkbox: { 'Select scorers': ['topic_sequence_match', 'action_sequence_match'] },
+      // eslint-disable-next-line camelcase
+      select: { topic_sequence_match: 'order_status' },
+    });
+
+    let utteranceCallCount = 0;
+    const utterances = ["What's the status of order #12345?", 'Where is my order 12345', 'Tell me about order #12345'];
+    h.inputStub.callsFake((cfg: InputCfg) => {
+      if (cfg.message.startsWith('Utterance')) {
+        return Promise.resolve(utterances[utteranceCallCount++]);
+      }
+      if (cfg.message.includes('action_sequence_match')) return Promise.resolve('Get_Order_Status');
+      throw new Error(`Unexpected input prompt: ${cfg.message}`);
+    });
+    // First two "another input utterance" → true, third → false.
+    let addAnotherCallCount = 0;
+    h.confirmStub.callsFake((cfg: ConfirmCfg) => {
+      if (cfg.message.includes('multiple input phrasings')) return Promise.resolve(true);
+      if (cfg.message.includes('Add another input utterance')) {
+        return Promise.resolve(addAnotherCallCount++ < 2);
+      }
+      if (cfg.message.includes('context variables')) return Promise.resolve(false);
+      if (cfg.message.includes('conversation history')) return Promise.resolve(false);
+      return Promise.resolve(false);
+    });
+
+    const mod = await loadModWithPrompts(h);
+    const tc: NgtTestCase = await mod.promptForNgtTestCase(TOPICS, BOTS, SUBJECT, 7, () => {});
+
+    expect(tc.inputs.map((i) => i.utterance)).to.deep.equal(utterances);
+    expect(tc.scorers).to.deep.equal([
+      { name: 'topic_sequence_match', expected: 'order_status' },
+      { name: 'action_sequence_match', expected: 'Get_Order_Status' },
+    ]);
+  });
+
+  it('routes agent_handoff_match expected to a select over local Bots minus the subject', async () => {
+    const h = harness({
+      confirms: {
+        'multiple input phrasings': false,
+        'context variables': false,
+        'Generate boilerplate conversation history': false,
+      },
+      inputs: { Utterance: 'I need a sales rep' },
+      checkbox: { 'Select scorers': ['agent_handoff_match'] },
+      // eslint-disable-next-line camelcase
+      select: { agent_handoff_match: 'SDRAgent' },
+    });
+
+    const mod = await loadModWithPrompts(h);
+    const tc: NgtTestCase = await mod.promptForNgtTestCase(TOPICS, BOTS, SUBJECT, 6, () => {});
+
+    expect(tc.scorers).to.deep.equal([{ name: 'agent_handoff_match', expected: 'SDRAgent' }]);
+
+    const handoffSelect = h.selectStub
+      .getCalls()
+      .find((c) => (c.args[0] as SelectCfg<string>).message.includes('agent_handoff_match'));
+    expect(handoffSelect, 'agent_handoff_match should be a select').to.not.be.undefined;
+    const choices = (handoffSelect!.args[0] as SelectCfg<string>).choices.map((c) => c.value);
+    expect(choices).to.deep.equal(['SDRAgent']);
+  });
+});

--- a/test/commands/agent/generate/test-spec.test.ts
+++ b/test/commands/agent/generate/test-spec.test.ts
@@ -26,6 +26,7 @@ import {
   getMetadataFilePaths,
   getPluginsAndFunctions,
   createCustomEvaluation,
+  inferRunnerFromMdPath,
 } from '../../../../src/commands/agent/generate/test-spec.js';
 
 describe('AgentGenerateTestSpec Helper Methods', () => {
@@ -775,6 +776,26 @@ describe('AgentGenerateTestSpec Helper Methods', () => {
       expect(evaluation.name).to.equal('numeric_comparison');
       expect(evaluation.parameters[1].value).to.equal('$.response.data[0].nested["special-key"].value');
       expect(evaluation.parameters[2].value).to.equal('3.14159');
+    });
+  });
+
+  describe('inferRunnerFromMdPath', () => {
+    it('infers testing-center for AiEvaluationDefinition extension', () => {
+      expect(inferRunnerFromMdPath(join('a', 'b', 'Foo.aiEvaluationDefinition-meta.xml'))).to.equal('testing-center');
+    });
+
+    it('infers agentforce-studio for AiTestingDefinition extension', () => {
+      expect(inferRunnerFromMdPath(join('a', 'b', 'Foo.aiTestingDefinition-meta.xml'))).to.equal('agentforce-studio');
+    });
+
+    it('throws UnknownDefinitionExtension for an unrecognized extension', () => {
+      expect(() => inferRunnerFromMdPath(join('a', 'b', 'Foo.xml'))).to.throw(/UnknownDefinitionExtension|must be/i);
+    });
+
+    it('throws UnknownDefinitionExtension for a Bot metadata file', () => {
+      expect(() => inferRunnerFromMdPath(join('a', 'b', 'Foo.bot-meta.xml'))).to.throw(
+        /UnknownDefinitionExtension|must be/i
+      );
     });
   });
 });

--- a/test/mock-projects/agent-generate-template/force-app/main/default/aiTestingDefinitions/ReturnsCheckoutSuite.aiTestingDefinition-meta.xml
+++ b/test/mock-projects/agent-generate-template/force-app/main/default/aiTestingDefinitions/ReturnsCheckoutSuite.aiTestingDefinition-meta.xml
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AiTestingDefinition xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>Validates the Returns / Checkout flow on agent v1.</description>
+    <name>ReturnsCheckoutSuite</name>
+    <subjectName>ReturnsAgent</subjectName>
+    <subjectType>AGENT</subjectType>
+    <subjectVersion>v1</subjectVersion>
+    <testCase>
+        <number>1</number>
+        <inputs>
+            <utterance>Where is my order #12345?</utterance>
+        </inputs>
+        <scorer>
+            <name>topic_sequence_match</name>
+            <expectedValue>order_status</expectedValue>
+        </scorer>
+        <scorer>
+            <name>action_sequence_match</name>
+            <expectedValue>Get_Order_Status</expectedValue>
+        </scorer>
+        <scorer>
+            <name>bot_response_rating</name>
+            <expectedValue>Agent looks up the order and returns its status</expectedValue>
+        </scorer>
+    </testCase>
+    <testCase>
+        <number>2</number>
+        <inputs>
+            <utterance>Cancel my order</utterance>
+        </inputs>
+        <scorer>
+            <name>topic_sequence_match</name>
+            <expectedValue>returns</expectedValue>
+        </scorer>
+        <scorer>
+            <name>bot_response_rating</name>
+            <expectedValue>Agent confirms the cancellation</expectedValue>
+        </scorer>
+        <scorer>
+            <name>coherence</name>
+        </scorer>
+        <scorer>
+            <name>factuality</name>
+        </scorer>
+        <scorer>
+            <name>output_latency_milliseconds</name>
+        </scorer>
+    </testCase>
+    <testCase>
+        <number>3</number>
+        <inputs>
+            <utterance>Verify identity and look up my order</utterance>
+        </inputs>
+        <scorer>
+            <name>action_sequence_match</name>
+            <expectedValue>[&apos;Verify_Customer&apos;,&apos;Get_Order_Status&apos;]</expectedValue>
+        </scorer>
+    </testCase>
+    <testCase>
+        <number>4</number>
+        <inputs>
+            <utterance>Yes, my email is jane@example.com</utterance>
+            <contextVariable>
+                <variableName>RoutableId</variableName>
+                <variableValue>0Mw000000000001</variableValue>
+            </contextVariable>
+            <conversationHistory>
+                <role>user</role>
+                <message>I need help with my order</message>
+                <index>0</index>
+            </conversationHistory>
+            <conversationHistory>
+                <role>agent</role>
+                <message>I can help. What&apos;s your email on file?</message>
+                <topic>identity_verification</topic>
+                <index>1</index>
+            </conversationHistory>
+        </inputs>
+        <scorer>
+            <name>topic_sequence_match</name>
+            <expectedValue>identity_verification</expectedValue>
+        </scorer>
+        <scorer>
+            <name>response_match</name>
+            <expectedValue>Agent verifies identity and continues</expectedValue>
+        </scorer>
+        <scorer>
+            <name>task_resolution</name>
+        </scorer>
+    </testCase>
+    <testCase>
+        <number>5</number>
+        <inputs>
+            <utterance>Show order details</utterance>
+        </inputs>
+        <scorer>
+            <name>factuality</name>
+        </scorer>
+        <scorer>
+            <name>completeness</name>
+        </scorer>
+    </testCase>
+    <testCase>
+        <number>6</number>
+        <inputs>
+            <utterance>I need a sales rep</utterance>
+        </inputs>
+        <scorer>
+            <name>topic_sequence_match</name>
+            <expectedValue>handoff</expectedValue>
+        </scorer>
+        <scorer>
+            <name>agent_handoff_match</name>
+            <expectedValue>SDRAgent</expectedValue>
+        </scorer>
+    </testCase>
+    <testCase>
+        <number>7</number>
+        <inputs>
+            <utterance>What&apos;s the status of order #12345?</utterance>
+        </inputs>
+        <scorer>
+            <name>topic_sequence_match</name>
+            <expectedValue>order_status</expectedValue>
+        </scorer>
+        <scorer>
+            <name>action_sequence_match</name>
+            <expectedValue>Get_Order_Status</expectedValue>
+        </scorer>
+    </testCase>
+    <testCase>
+        <number>8</number>
+        <inputs>
+            <utterance>Where is my order 12345</utterance>
+        </inputs>
+        <scorer>
+            <name>topic_sequence_match</name>
+            <expectedValue>order_status</expectedValue>
+        </scorer>
+        <scorer>
+            <name>action_sequence_match</name>
+            <expectedValue>Get_Order_Status</expectedValue>
+        </scorer>
+    </testCase>
+    <testCase>
+        <number>9</number>
+        <inputs>
+            <utterance>Tell me about order #12345</utterance>
+        </inputs>
+        <scorer>
+            <name>topic_sequence_match</name>
+            <expectedValue>order_status</expectedValue>
+        </scorer>
+        <scorer>
+            <name>action_sequence_match</name>
+            <expectedValue>Get_Order_Status</expectedValue>
+        </scorer>
+    </testCase>
+</AiTestingDefinition>

--- a/test/nuts/agent.generate.test-spec.nut.ts
+++ b/test/nuts/agent.generate.test-spec.nut.ts
@@ -15,7 +15,7 @@
  */
 
 import { join } from 'node:path';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { expect } from 'chai';
 import { genUniqueString, TestSession } from '@salesforce/cli-plugins-testkit';
 import { execCmd } from '@salesforce/cli-plugins-testkit';
@@ -77,5 +77,70 @@ describe('agent generate test-spec NUTs', function () {
     execCmd(`agent generate test-spec --from-definition ${invalidFile} --output-file ${outputFile} --force-overwrite`, {
       ensureExitCode: 'nonZero',
     });
+  });
+
+  it('should generate NGT test spec from AiTestingDefinition with explicit --test-runner agentforce-studio', () => {
+    const definitionFile = join(
+      session.project.dir,
+      'force-app',
+      'main',
+      'default',
+      'aiTestingDefinitions',
+      'ReturnsCheckoutSuite.aiTestingDefinition-meta.xml'
+    );
+    const outputFile = join(session.project.dir, 'specs', genUniqueString('ngtTestSpec_%s.yaml'));
+
+    execCmd(
+      `agent generate test-spec --from-definition ${definitionFile} --test-runner agentforce-studio --output-file ${outputFile} --force-overwrite`,
+      { ensureExitCode: 0 }
+    );
+
+    expect(existsSync(outputFile)).to.be.true;
+    const yaml = readFileSync(outputFile, 'utf8');
+    // NGT-shaped YAML: per-case `inputs:` array and `scorers:` array.
+    expect(yaml).to.match(/inputs:/);
+    expect(yaml).to.match(/scorers:/);
+    expect(yaml).to.match(/subjectName:\s*ReturnsAgent/);
+  });
+
+  it('should infer agentforce-studio runner from AiTestingDefinition extension when --test-runner is omitted', () => {
+    const definitionFile = join(
+      session.project.dir,
+      'force-app',
+      'main',
+      'default',
+      'aiTestingDefinitions',
+      'ReturnsCheckoutSuite.aiTestingDefinition-meta.xml'
+    );
+    const outputFile = join(session.project.dir, 'specs', genUniqueString('ngtTestSpec_%s.yaml'));
+
+    execCmd(
+      `agent generate test-spec --from-definition ${definitionFile} --output-file ${outputFile} --force-overwrite`,
+      { ensureExitCode: 0 }
+    );
+
+    expect(existsSync(outputFile)).to.be.true;
+    const yaml = readFileSync(outputFile, 'utf8');
+    expect(yaml).to.match(/inputs:/);
+    expect(yaml).to.match(/scorers:/);
+  });
+
+  it('should fail with RunnerMismatch when legacy XML is paired with --test-runner agentforce-studio', () => {
+    const definitionFile = join(
+      session.project.dir,
+      'force-app',
+      'main',
+      'default',
+      'aiEvaluationDefinitions',
+      'Local_Info_Agent_Test.aiEvaluationDefinition-meta.xml'
+    );
+    const outputFile = join(session.project.dir, 'specs', genUniqueString('ngtTestSpec_%s.yaml'));
+
+    const result = execCmd(
+      `agent generate test-spec --from-definition ${definitionFile} --test-runner agentforce-studio --output-file ${outputFile} --force-overwrite`,
+      { ensureExitCode: 'nonZero' }
+    );
+    const stderr = result.shellOutput.stderr ?? '';
+    expect(stderr).to.match(/RunnerMismatch|test-runner|extension/i);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1411,10 +1411,10 @@
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
-"@salesforce/agents@^1.8.4":
-  version "1.8.4"
-  resolved "https://registry.yarnpkg.com/@salesforce/agents/-/agents-1.8.4.tgz#2d51be8575800d066d56ce542d8040439ccfe8fc"
-  integrity sha512-ag5OxiKmBJY82IEWSZoK5NtvpgJCW1VhsSi/vi4quyvEOLpNyPKfGcFahJJaXMB5VFGRSdSa9+LIoqMmL9nlHQ==
+"@salesforce/agents@^1.9.0":
+  version "1.9.0"
+  resolved "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@salesforce/agents/-/agents-1.9.0.tgz#58d5a48f164942009ae57bb15a0de8c6729a72c4"
+  integrity sha512-CcMVeKfzUc5I/64JSUiFwCuYjQjPbx9EUyXeUfYEpB65f8sRpSQtbO3xJe2jjrrEo0RUVzU9gJSh4kB+SnzgJg==
   dependencies:
     "@salesforce/core" "^8.31.0"
     "@salesforce/kit" "^3.2.6"


### PR DESCRIPTION
### What does this PR do?

Adds NGT (`AiTestingDefinition`) authoring to `sf agent generate test-spec`. Bumps `@salesforce/agents` to `^1.9.0` to consume the new NGT surface.

**Mode 2 — `--from-definition` (file dispatch):**
  - Accepts both `*.aiEvaluationDefinition-meta.xml` (legacy) and `*.aiTestingDefinition-meta.xml` (NGT)
  - Runner is inferred from the extension via `inferRunnerFromMdPath`; passing `--test-runner` is now optional in Mode 2
  - Mismatched extension + flag throws `RunnerMismatch` with a clear remediation message

**Mode 1 — interactive walkthrough:**
  - Gains an NGT branch when `--test-runner agentforce-studio` is set
  - `expected` prompts are gated by `NgtScorerCatalog[name].needsExpected` — quality scorers (factuality, coherence, completeness, etc.) and numeric scorers (output_latency_milliseconds) skip the prompt entirely
  - `topic_sequence_match.expected` is a select over the local GenAiPlugin DeveloperNames; `agent_handoff_match.expected` is a select over local Bots minus the current subject; everything else is free-form
  - a rescue prompt offering boilerplate. Decline → warn so `validateNgtSpec` can flag it later. Accept → auto-stamp the canonical two-turn history.

  **Output:**
  - NGT mode → `specs/<subjectName>-ngtTestSpec.yaml`
  - Legacy → `specs/<subjectName>-testSpec.yaml`

### What issues does this PR fix or reference?
@W-22904110@