### PR TITLE
fix: yarn.lock repo cleanup and stable test time filter W-23182333

### DIFF
--- a/test/commands/agent/trace/list.test.ts
+++ b/test/commands/agent/trace/list.test.ts
@@ -163,7 +163,7 @@ describe('agent trace list', () => {
     });
 
     it('returns only traces at or after the given datetime', async () => {
-      const result = await AgentTraceList.run(['--since', '2026-04-07T17:00:00.000Z']);
+      const result = await AgentTraceList.run(['--since', RECENT_MTIME.toISOString()]);
       const planIds = result.map((r: any) => r.planId);
       expect(planIds).to.include('plan-1'); // exactly equal — mtime >= since
       expect(planIds).to.not.include('plan-2');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1413,7 +1413,7 @@
 
 "@salesforce/agents@^1.9.0":
   version "1.9.0"
-  resolved "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@salesforce/agents/-/agents-1.9.0.tgz#58d5a48f164942009ae57bb15a0de8c6729a72c4"
+  resolved "https://registry.yarnpkg.com/@salesforce/agents/-/agents-1.9.0.tgz#58d5a48f164942009ae57bb15a0de8c6729a72c4"
   integrity sha512-CcMVeKfzUc5I/64JSUiFwCuYjQjPbx9EUyXeUfYEpB65f8sRpSQtbO3xJe2jjrrEo0RUVzU9gJSh4kB+SnzgJg==
   dependencies:
     "@salesforce/core" "^8.31.0"


### PR DESCRIPTION
### What does this PR do?
- **yarn.lock**: re-resolve `@salesforce/agents` (and its dep graph) against the correct public registry — the lockfile had a bad repo reference that broke installs.
- **test/commands/agent/trace/list.test.ts**: replace the hardcoded `'2026-04-07T17:00:00.000Z'` `--since` value with `RECENT_MTIME.toISOString()`, so the time-filter test stays anchored to the same relative window the fixture data uses (`Date.now() - 7d`) instead of drifting out of range as the clock moves forward.

### What issues does this PR fix or reference?
@W-23182333@