### PR TITLE
fix: W-23261603 pin CTC step to Node 22 until change-case-management supports No…

### DIFF
--- a/.github/workflows/onRelease.yml
+++ b/.github/workflows/onRelease.yml
@@ -29,5 +29,6 @@ jobs:
       sign: true
       tag: ${{ needs.getDistTag.outputs.tag || 'latest' }}
       githubTag: ${{ github.event.release.tag_name || inputs.tag }}
+      nodeVersion: 'lts/-1'
 
     secrets: inherit


### PR DESCRIPTION
…de 24

@W-12345678@ 

The GitHub Actions runner upgraded to Node 24 (lts/*), which causes @salesforce/change-case-management to fail with an unsettled top-level await warning and empty output. Pin to lts/-1 (Node 22) for the publish workflow until the CTC tooling is updated.

### What does this PR do?

### What issues does this PR fix or reference?
