### PR TITLE
fix: W-23261603 pin CTC to Node 20 — unsettled await affects Node 22.23 too

### DIFF
--- a/.github/workflows/onRelease.yml
+++ b/.github/workflows/onRelease.yml
@@ -29,6 +29,6 @@ jobs:
       sign: true
       tag: ${{ needs.getDistTag.outputs.tag || 'latest' }}
       githubTag: ${{ github.event.release.tag_name || inputs.tag }}
-      nodeVersion: 'lts/-1'
+      nodeVersion: '20'
 
     secrets: inherit


### PR DESCRIPTION
## Summary
- Pin `nodeVersion: '20'` in the publish workflow — `lts/-1` (Node 22.23.0) also triggers the unsettled top-level await bug in `@salesforce/change-case-management`

@W-12345678@

## Context
PR #454 pinned to `lts/-1` but Node 22.23.0 backported the unsettled top-level await detection from Node 24, so CTC still fails. Node 20 is the last version that doesn't have this behavior.

Failing run (1.44.1 on Node 22.23.0): https://github.com/salesforcecli/plugin-agent/actions/runs/28488973503

## Test plan
- [ ] Re-run the 1.44.1 release via `workflow_dispatch` after merge and confirm CTC opens successfully
- [ ] Remove this pin once `@salesforce/change-case-management` publishes a fix for the top-level await issue