### PR TITLE
fix: bump @salesforce/agents to 1.10.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@inquirer/prompts": "^7.10.1",
     "@oclif/core": "^4",
     "@oclif/multi-stage-output": "^0.8.36",
-    "@salesforce/agents": "^1.10.1",
+    "@salesforce/agents": "^1.10.2",
     "@salesforce/core": "^8.28.3",
     "@salesforce/kit": "^3.2.6",
     "@salesforce/sf-plugins-core": "^12.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1411,10 +1411,10 @@
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
-"@salesforce/agents@^1.10.1":
-  version "1.10.1"
-  resolved "https://registry.yarnpkg.com/@salesforce/agents/-/agents-1.10.1.tgz#b0f0a7ff0a6c7052577ec8c15d277de36ac7c69f"
-  integrity sha512-E5VjrKSc61obYujzYXeFbYlEAUV1c6wjv8UXtReDaPkx7Y6M0FQRqlRfXR1POinuXetNQneTmkSvDtRO8jgm1g==
+"@salesforce/agents@^1.10.2":
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/@salesforce/agents/-/agents-1.10.2.tgz#9c91399b761c60c6a9f6d3e700e59756c077777f"
+  integrity sha512-SB2+2YhbgktmGIU8TGQcpenSpGtC2hZLEBNMpiI+KwcRwhV8TkXN0tWTEcEpOqXdXHYR1OrMkIoOqB+bgG4ROQ==
   dependencies:
     "@salesforce/core" "^8.31.0"
     "@salesforce/kit" "^3.2.6"


### PR DESCRIPTION
Picks up forcedotcom/agents#310, which removes erroneous _vN suffix stripping from the publish developerName.

### What does this PR do?

### What issues does this PR fix or reference?
