### PR TITLE
W-23278444: fix: unpin CTC Node version

### DIFF
--- a/.github/workflows/onRelease.yml
+++ b/.github/workflows/onRelease.yml
@@ -29,6 +29,5 @@ jobs:
       sign: true
       tag: ${{ needs.getDistTag.outputs.tag || 'latest' }}
       githubTag: ${{ github.event.release.tag_name || inputs.tag }}
-      nodeVersion: '20'
 
     secrets: inherit


### PR DESCRIPTION
@W-23278444@

## What

Removes the `nodeVersion: '20'` pin from the `npm` publish job in `.github/workflows/onRelease.yml`.

## Why

This pin was originally added in a52f75f (`nodeVersion: 'lts/-1'`) and later adjusted to `'20'` in #455 as a workaround for `@salesforce/change-case-management` failing on newer Node with an unsettled top-level `await` warning and empty output during the CTC step. This PR removes the line so the publish workflow uses the default Node version again.

Work Item: @W-23278444@