### PR TITLE
fix(deps): bump @salesforce/agents from 1.10.2 to 1.10.3 @W-23371674

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@inquirer/prompts": "^7.10.1",
     "@oclif/core": "^4",
     "@oclif/multi-stage-output": "^0.8.36",
-    "@salesforce/agents": "^1.10.2",
+    "@salesforce/agents": "^1.10.3",
     "@salesforce/core": "^8.28.3",
     "@salesforce/kit": "^3.2.6",
     "@salesforce/sf-plugins-core": "^12.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1411,10 +1411,10 @@
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
-"@salesforce/agents@^1.10.2":
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/@salesforce/agents/-/agents-1.10.2.tgz#9c91399b761c60c6a9f6d3e700e59756c077777f"
-  integrity sha512-SB2+2YhbgktmGIU8TGQcpenSpGtC2hZLEBNMpiI+KwcRwhV8TkXN0tWTEcEpOqXdXHYR1OrMkIoOqB+bgG4ROQ==
+"@salesforce/agents@^1.10.3":
+  version "1.10.3"
+  resolved "https://registry.yarnpkg.com/@salesforce/agents/-/agents-1.10.3.tgz#5f78f25624c26ca0679b7654c60808d2e612297f"
+  integrity sha512-Cww6DizTMcPGi9oK8JrVh2Yt2Mg00l7qUOPRS2U/oRFkXXoMBzzotlA6aj44EuX9PAHR93N1DVUM4WCPTzaSQg==
   dependencies:
     "@salesforce/core" "^8.31.0"
     "@salesforce/kit" "^3.2.6"


### PR DESCRIPTION
## What

Bump `@salesforce/agents` from `1.10.2` to `1.10.3` (package.json + yarn.lock).

## Why

`1.10.3` contains the `fetchMcpServer` empty-body fix
([forcedotcom/agents#318](https://github.com/forcedotcom/agents/pull/318)),
which resolves a **300s `HeadersTimeoutError` hang** on `sf agent mcp fetch`.

A bodyless `POST` over HTTP/2 left the request stream half-open, so
jsforce/undici never received the response headers and the call blocked
until the 300s headers timeout. `1.10.3` sends an explicit empty `{}` body.

`agents@1.10.3` is published on npm, but the CLI pins the exact version from
this plugin's lockfile, so the fix does not reach `sf` until this bump is
released.

## Test plan

- `yarn build` + full test suite green (ran on push via pre-push hook).
- Verified locally that a CLI built with `agents@1.10.3` drops `sf agent mcp
  fetch` from 300s to ~5s across every MCP server tested.
