### PR TITLE
fix: bump @salesforce/agents to 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@inquirer/prompts": "^7.10.1",
     "@oclif/core": "^4",
     "@oclif/multi-stage-output": "^0.8.36",
-    "@salesforce/agents": "^2.0.0",
+    "@salesforce/agents": "^2.0.1",
     "@salesforce/core": "^9.0.0",
     "@salesforce/kit": "^4.0.0",
     "@salesforce/sf-plugins-core": "^13.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1396,10 +1396,10 @@
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
-"@salesforce/agents@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@salesforce/agents/-/agents-2.0.0.tgz#e3cc03704899991f2078296c3500d667b654c178"
-  integrity sha512-Ry/+X8WG5+kRdGLpJdtxTSqZysXWRLBkZ+KlzHv+G+ZneEbnLac8blkMKUh0yefsxa/drPXFcvvbsI8kjTwoRw==
+"@salesforce/agents@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/agents/-/agents-2.0.1.tgz#032c97245e2295a7fb035c73e3a967d66795c55d"
+  integrity sha512-kouvkSPi5MLT1BWOUhsPxZhpqBgN8qshRefn3WU6D74nZI8Crv0Tj0clelmEWMcZXhkiJf+Cznrpyu+2SI5O8w==
   dependencies:
     "@salesforce/core" "^9.0.0"
     "@salesforce/kit" "^4.0.0"


### PR DESCRIPTION
Bumps `@salesforce/agents` from `^2.0.0` to `^2.0.1`.

Picks up [forcedotcom/agents#329](https://github.com/forcedotcom/agents/pull/329): fixes `sf agent publish authoring-bundle --api-name <name>_<version>` deploying the wrong (unversioned) bundle directory for a versioned publish.

## Verification
- `yarn build` clean (lint + compile)
- Full test suite green via pre-push hook
- `yarn.lock` resolves `2.0.1` from the public registry