### PR TITLE
fix: handle null MCP asset input

### DIFF
--- a/src/commands/agent/mcp/asset/replace.ts
+++ b/src/commands/agent/mcp/asset/replace.ts
@@ -73,9 +73,9 @@ export default class ApiCatalogMcpServerAssetReplace extends SfCommand<ApiCatalo
       throw new SfError(messages.getMessage('error.invalidJson'), 'InvalidJson', [], 1);
     }
 
-    const assets = (Array.isArray(parsed) ? parsed : (parsed as { assets?: McpServerAssetReplaceItem[] }).assets) as
-      | McpServerAssetReplaceItem[]
-      | undefined;
+    const assets = (
+      Array.isArray(parsed) ? parsed : (parsed as { assets?: McpServerAssetReplaceItem[] } | null)?.assets
+    ) as McpServerAssetReplaceItem[] | undefined;
     if (!assets || !Array.isArray(assets)) {
       throw new SfError(messages.getMessage('error.invalidShape'), 'InvalidShape', [], 1);
     }

--- a/test/commands/agent/mcp/mcp.test.ts
+++ b/test/commands/agent/mcp/mcp.test.ts
@@ -360,6 +360,19 @@ describe('agent mcp commands', () => {
     }
   });
 
+  it('asset replace throws InvalidShape for null JSON', async () => {
+    const testOrg = new MockTestOrgData();
+    await $$.stubAuths(testOrg);
+    $$.fakeConnectionRequest = () => Promise.resolve({} as any);
+
+    try {
+      await AgentMcpAssetReplace.run(['--target-org', testOrg.username, '--mcp-server-id', '0XS1', '--assets', 'null']);
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect((err as { name: string }).name).to.equal('InvalidShape');
+    }
+  });
+
   it('get returns the server and strips the secret on read', async () => {
     const testOrg = new MockTestOrgData();
     await $$.stubAuths(testOrg);


### PR DESCRIPTION
### What does this PR do?

Handles `null` JSON input passed to `sf agent mcp asset replace --assets`.

Previously, `null` was successfully parsed as JSON and the command attempted to access `.assets` on it, resulting in a raw `TypeError`:

```text
Cannot read properties of null (reading 'assets')
```

This change uses safe property access so invalid input falls through to the existing `InvalidShape` validation.

A regression test was added for `--assets null`.

Test results:

- `yarn test:only` — 448 passing
- `yarn build` — successful

### What issues does this PR fix or reference?

Fixes forcedotcom/cli#3625