### PR TITLE
fix: bump @salesforce/agents to 2.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@inquirer/prompts": "^7.10.1",
     "@oclif/core": "^4",
     "@oclif/multi-stage-output": "^0.8.36",
-    "@salesforce/agents": "^2.0.2",
+    "@salesforce/agents": "^2.0.4",
     "@salesforce/core": "^9.0.0",
     "@salesforce/kit": "^4.0.0",
     "@salesforce/sf-plugins-core": "^13.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1396,10 +1396,10 @@
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
-"@salesforce/agents@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@salesforce/agents/-/agents-2.0.2.tgz#3d747995ee0e7383fa6bab072fdc0e1de04d6b33"
-  integrity sha512-9MOWualHDUaz7oonZXF06Gb5lnY4HzY65sGWrQMa2Waj3uGeY0mLiPQZhHY7Q0HzzwTc00AvAkDBqt6vEsmaQg==
+"@salesforce/agents@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@salesforce/agents/-/agents-2.0.4.tgz#143afb797800cb7795c6812a802964512ff79bf9"
+  integrity sha512-ZUZH6+y4pfowqw6OMeF4rifsSObr0dyMZsBlkgkvwexqKXyg6igKyfwmN3NbjHfgtSfeyJN6n0dfsA3U51qBrQ==
   dependencies:
     "@salesforce/core" "^9.0.0"
     "@salesforce/kit" "^4.0.0"


### PR DESCRIPTION
Bumps `@salesforce/agents` from `^2.0.2` to `^2.0.4`.

Picks up the fixes released in 2.0.3 and 2.0.4:
- `x-attributed-client: no-builder` header on `--api-name` preview start (@W-23896240@)
- throw when `groundingContext` is passed without `promptTemplateName` in `createSpec` (@W-23896239@)
- record reasoning traces for `--api-name` previews via the v1.1 plans endpoint (@W-23896220@)

Updated `package.json` and `yarn.lock`.