### PR TITLE
do-not-merge/testing-nuts-failure-logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2455,3 +2455,5 @@ EXAMPLES
 _See code: [src/commands/agent/validate/authoring-bundle.ts](https://github.com/salesforcecli/plugin-agent/blob/2.0.3/src/commands/agent/validate/authoring-bundle.ts)_
 
 <!-- commandsstop -->
+
+<!-- CI trigger: verifying NUT failure-log output ([NUT-CONTEXT] / [NUT-FAILURE]). Do not merge. -->


### PR DESCRIPTION
**Do not merge.** Throwaway PR to trigger CI and verify the new NUT failure-logging output in the z-series.

Only change is a comment appended to README.md — the point is to run plugin-agent's NUTs and confirm:
- `[NUT-CONTEXT]` appears (every run) with orgId + pod + UTC timestamp.
- `[NUT-FAILURE]` appears for the deterministic z3 failure (`history never created`). Note: z4 fails in a `before all` hook, which the root `afterEach` doesn't catch — only `[NUT-CONTEXT]` covers that run.

Grep the job logs for `[NUT-CONTEXT]` / `[NUT-FAILURE]`. Close without merging when done.

Companion do-not-merge PR in agents: forcedotcom/agents#343.