### PR TITLE
chore(deps): bump @salesforce/agents to 2.0.5 @W-23915028@

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@inquirer/prompts": "^7.10.1",
     "@oclif/core": "^4",
     "@oclif/multi-stage-output": "^0.8.36",
-    "@salesforce/agents": "^2.0.4",
+    "@salesforce/agents": "^2.0.5",
     "@salesforce/core": "^9.0.0",
     "@salesforce/kit": "^4.0.0",
     "@salesforce/sf-plugins-core": "^13.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1396,10 +1396,10 @@
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
-"@salesforce/agents@^2.0.4":
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@salesforce/agents/-/agents-2.0.4.tgz#143afb797800cb7795c6812a802964512ff79bf9"
-  integrity sha512-ZUZH6+y4pfowqw6OMeF4rifsSObr0dyMZsBlkgkvwexqKXyg6igKyfwmN3NbjHfgtSfeyJN6n0dfsA3U51qBrQ==
+"@salesforce/agents@^2.0.5":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@salesforce/agents/-/agents-2.0.5.tgz#aea95c55936267c3f7e6a706f374c179f8a46796"
+  integrity sha512-WwgPsf3PI0urgM8ctbpIHKmcXbcOlKwbF7KYnJBVuSELDNlZWECXPSXmFH2JVII0D/YQxDweXLIVbm6rZrlNng==
   dependencies:
     "@salesforce/core" "^9.0.0"
     "@salesforce/kit" "^4.0.0"


### PR DESCRIPTION
Bumps `@salesforce/agents` `^2.0.4` → `^2.0.5`.

2.0.5 (forcedotcom/agents#345) contains the `getAllTraces` "history never created" fix. This resolves the z3 `agent preview` NUT (`should reflect --context-variables overrides in the live preview session trace`) that was failing against the previously-published lib — the last known-expected red after #477 merged.

## Verification
- `yarn build` clean against 2.0.5
- lockfile resolves to 2.0.5

Closes out the cross-repo NUT fix chain: plugin-agent#477 → agents#345 (released 2.0.5) → this bump.