### PR TITLE
chore(deps): bump @salesforce/agents to 2.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@inquirer/prompts": "^7.10.1",
     "@oclif/core": "^4",
     "@oclif/multi-stage-output": "^0.8.36",
-    "@salesforce/agents": "^2.0.5",
+    "@salesforce/agents": "^2.0.6",
     "@salesforce/core": "^9.0.0",
     "@salesforce/kit": "^4.0.0",
     "@salesforce/sf-plugins-core": "^13.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1396,10 +1396,10 @@
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
-"@salesforce/agents@^2.0.5":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@salesforce/agents/-/agents-2.0.5.tgz#aea95c55936267c3f7e6a706f374c179f8a46796"
-  integrity sha512-WwgPsf3PI0urgM8ctbpIHKmcXbcOlKwbF7KYnJBVuSELDNlZWECXPSXmFH2JVII0D/YQxDweXLIVbm6rZrlNng==
+"@salesforce/agents@^2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@salesforce/agents/-/agents-2.0.6.tgz#f7f36fff866d87963fc20190434c7b504fbafef4"
+  integrity sha512-RF/h/1f9UBPyz91KszoFuGRNI+LkeXQPFuOvCxxWdFBatxMN5wkpcCQsoZ/RIOiE7VrHzjoqk8UDFXPYENmo5g==
   dependencies:
     "@salesforce/core" "^9.0.0"
     "@salesforce/kit" "^4.0.0"


### PR DESCRIPTION
## What

Bumps `@salesforce/agents` from `^2.0.5` to `^2.0.6` (`package.json` + `yarn.lock`).

## Why

`@salesforce/agents@2.0.6` ships the fix for `sf agent publish authoring-bundle` crashing with `TypeError: Cannot read properties of undefined (reading 'map')` when the agent contains a `related_agent` node (compiled from an AgentScript `connected_subagent` block, which has no `tools` array). This was blocking a customer from publishing an Orchestrator / multi-agent (Super Agent) via the CLI.

- Upstream fix: forcedotcom/agents#350
- `@salesforce/agents@2.0.6` is published and tagged `latest` on npm.

## Notes

- The `yarn.lock` entry was updated surgically (version, resolved, integrity). `2.0.6` introduces no new/changed transitive dependencies vs `2.0.5`, so no other lockfile entries change.