### PR TITLE
test: fix flaky `agent create` NUT (Bot User race)

### DIFF
--- a/test/nuts/z0.agent.create.nut.ts
+++ b/test/nuts/z0.agent.create.nut.ts
@@ -15,13 +15,13 @@
  */
 
 import { join } from 'node:path';
-import { readdirSync, statSync } from 'node:fs';
+import { appendFileSync, readdirSync, statSync } from 'node:fs';
 import { expect } from 'chai';
 import { genUniqueString, TestSession } from '@salesforce/cli-plugins-testkit';
 import { execCmd } from '@salesforce/cli-plugins-testkit';
 import type { AgentCreateSpecResult } from '../../src/commands/agent/generate/agent-spec.js';
 import type { AgentCreateResult } from '../../src/commands/agent/create.js';
-import { getTestSession, getUsername } from './shared-setup.js';
+import { getAgentUsername, getTestSession, getUsername } from './shared-setup.js';
 
 /* eslint-disable no-console */
 
@@ -68,6 +68,18 @@ describe('agent create', function () {
     const expectedFilePath = join(session.project.dir, 'specs', specFileName);
     const name = 'Plugin Agent Test';
     const apiName = 'Plugin_Agent_Test';
+
+    // Reuse the Bot User pre-provisioned in shared setup (via `org create agent-user`) instead of
+    // letting core auto-create one during the save. The 'customer' agentType maps to core's
+    // EinsteinServiceAgent, which requires a licensed Bot User; when no user is supplied, core creates
+    // that user in the SAME transaction as the BotDefinition save, and the pre-save validation trigger
+    // intermittently cannot see the just-created license/permset assignment, failing with "User
+    // doesn't have access to agent." `agent create` sets agentSettings.userId from the spec's
+    // `agentUser`, so writing the already-committed agent user into the spec removes that race.
+    const agentUser = getAgentUsername();
+    expect(agentUser, 'agent user should have been provisioned in shared setup').to.be.a('string');
+    appendFileSync(expectedFilePath, `\nagentUser: "${agentUser!}"\n`);
+
     const command = `agent create --spec ${expectedFilePath} --target-org ${username} --name "${name}" --api-name ${apiName} --json`;
     const result = execCmd<AgentCreateResult>(command, { ensureExitCode: 0 }).jsonOutput?.result;
     expect(result).to.be.ok;


### PR DESCRIPTION
## What

`test/nuts/z0.agent.create.nut.ts` (`agent create > should create new agent in org`) fails intermittently, pod-dependent, with:

```
Error creating agent : User doesn't have access to agent.
isSuccess: false
```

## Root cause

The `customer` agentType maps to core's `EinsteinServiceAgent`, which requires a Bot User holding the Digital Agent license + `AgentforceServiceAgentUser` permset. `agent create` only sets `agentSettings.userId` when the spec YAML has an `agentUser` field (`src/commands/agent/create.ts`). The NUT generated a spec with no `agentUser`, so `Agent.create` received no `userId` and core auto-created the Bot User in the **same transaction** as the BotDefinition save. The pre-save validation trigger intermittently cannot see the fresh license/permset assignment and rejects with "User doesn't have access to agent."

Shared setup already provisions an agent user via `org create agent-user` and exposes it through `getAgentUsername()`, but it was only wired into publish (`z2`), not create.

## Fix

Write the already-committed agent user into the spec's `agentUser` field before running `agent create`, so the command threads `agentSettings.userId` and core reuses the committed user instead of racing on a fresh one. Mirrors the analogous fix in `@salesforce/agents` (forcedotcom/agents#358).

## Testing

- `yarn build` (compile + lint) passes.
- The NUT needs a scratch org + default dev hub, not run in this environment. Because the failure is a race, verify with several runs across pods before trusting green.

Test-only change; no runtime code touched.