### PR TITLE
chore: Update codeowners and Gus info @W-24127726

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,9 @@
-# Techical writers will be added as reviewers on markdown changes.
-*.md @salesforcecli/cli-docs
+# The agents team owns everything in this repo by default.
+* @salesforcecli/agents
+
+# Technical writers will be added as additional reviewers on markdown changes.
+*.md @salesforcecli/agents @salesforcecli/cli-docs
 
 # Comment line immediately above ownership line is reserved for related other information. Please be careful while editing.
 #ECCN:Open Source
+#GUSINFO:Authoring Agent, Authoring Agent


### PR DESCRIPTION
Sets `@forcedotcom/agents` as the default owner via a catch-all, adds the team as an additional reviewer on markdown, and adds the `#GUSINFO:Authoring Agent` tag.

@W-24127726@